### PR TITLE
Add tests for the dockerflow endpoints.

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -20,6 +20,9 @@ mccabe==0.6.1 \
     --hash=sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42
 pytest==3.0.7 \
     --hash=sha256:66f332ae62593b874a648b10a8cb106bfdacd2c6288ed7dec3713c3a808a6017
+pytest-flask==0.10.0 \
+    --hash=sha256:2c5a36f9033ef8b6f85ddbefaebdd4f89197fc283f94b20dfe1a1beba4b77f03 \
+    --hash=sha256:657c7de386215ab0230bee4d76ace0339ae82fcbb34e134e17a29f65032eef03
 pycodestyle==2.3.1 \
     --hash=sha256:6c4245ade1edfad79c3446fadfc96b0de2759662dc29d07d80a6f27ad1ca6ba9
 pyparsing==2.2.0 \

--- a/landoui/dockerflow.py
+++ b/landoui/dockerflow.py
@@ -16,7 +16,7 @@ def heartbeat():
     and return a 200 iff those services and the app itself are
     performing normally. Return a 5XX if something goes wrong.
     """
-    # TODO check backing services
+    # TODO check backing services and update tests
     return '', 200
 
 

--- a/tests/test_dockerflow.py
+++ b/tests/test_dockerflow.py
@@ -1,0 +1,66 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import json
+import os
+import binascii
+
+import click
+import pytest
+
+from landoui.app import create_app
+
+
+@pytest.fixture
+def versionfile(tmpdir):
+    """Provide a temporary version.json on disk."""
+    v = tmpdir.mkdir('app').join('version.json')
+    v.write(
+        json.dumps(
+            {
+                'source': 'https://github.com/mozilla-conduit/lando-api',
+                'version': '0.0.0',
+                'commit': '',
+                'build': 'test',
+            }
+        )
+    )
+    return v
+
+
+@pytest.fixture
+def app(versionfile):
+    """Needed for pytest-flask."""
+    return click.Context.invoke(
+        None,
+        create_app,
+        run_dev_server=False,
+        debug=True,
+        port=80,
+        host='0.0.0.0',
+        version_path=versionfile.strpath,
+        secret_key=str(binascii.b2a_hex(os.urandom(15))),
+        session_cookie_name='landoui-test',
+        session_cookie_domain='',
+        session_cookie_secure=False,
+    )
+
+
+def test_dockerflow_lb_endpoint_returns_200(client):
+    assert client.get('/__lbheartbeat__').status_code == 200
+
+
+def test_dockerflow_heartbeat_endpoint_returns_200(client):
+    assert client.get('/__heartbeat__').status_code == 200
+
+
+def test_dockerflow_version_endpoint_response(client):
+    response = client.get('/__version__')
+    assert response.status_code == 200
+    assert response.content_type == 'application/json'
+
+
+def test_dockerflow_version_matches_disk_contents(client, versionfile):
+    response = client.get('/__version__')
+    assert response.json == json.load(versionfile.open())


### PR DESCRIPTION
Adds the py-flakes library to the dev-requirements.
py-flakes provides some extra fixtures (mainly the client fixutre)
which allows us to easily make requests to the test application and
check the response.

The tests added should all pass, and are based on those from the
lando-api writen by mars.

If the tests do not pass when running `invoke test` intitally, then
most likely you will have to rebuild the test container. Running
`docker-compose build --no-cache` sometimes is not enough, because the
test containers use a different project scope. Instead to run:
`docker-compose -p testlandoui build --no-cache` to resolve the issue.