### PR TITLE
Update invoke tasks and fix broken tests

### DIFF
--- a/landoui/app.py
+++ b/landoui/app.py
@@ -31,9 +31,7 @@ oidc = None
     '--session-cookie-name', envvar='SESSION_COOKIE_NAME', default=None
 )
 @click.option(
-    '--session-cookie-domain',
-    envvar='SESSION_COOKIE_DOMAIN',
-    default='lando.mozilla.org'
+    '--session-cookie-domain', envvar='SESSION_COOKIE_DOMAIN', default=None
 )
 @click.option(
     '--session-cookie-secure', envvar='SESSION_COOKIE_SECURE', default=1

--- a/tests/test_dockerflow.py
+++ b/tests/test_dockerflow.py
@@ -41,8 +41,8 @@ def app(versionfile):
         host='0.0.0.0',
         version_path=versionfile.strpath,
         secret_key=str(binascii.b2a_hex(os.urandom(15))),
-        session_cookie_name='landoui-test',
-        session_cookie_domain='',
+        session_cookie_name='lando-ui',
+        session_cookie_domain='lando-ui:7777',
         session_cookie_secure=False,
     )
 


### PR DESCRIPTION
### Simplify invoke tasks that run python unit tests.

The old invoke file was based on our invoke file from our conduit hg monorepo - which had many different containers building and running in unision.

In our case we're using invoke simply as an alias for docker-compose to prevent us from having to type everything out.

The old invoke file created a new project space for the test containers which was causing problems because changes to the Dockerfile or the python requirements wouldn't cause rebuild of images in the testproject space (unknown reason why). So what would happen is I would run `invoke test` but I would get a test failure even though everything looked fine on my end - the underlying cause was that the test container wasn't refreshed and it was not obvious when this happened.

This commit changes the tasks.py file to use the same project space as the normal development one. Now if the tests are failing it is because of a problem that you should also have encountered when running the dev containers.

### Update tests to account for required SERVER_NAME setting

With the addition of the Auth0 changes, the Flask app now requires that the SERVER_NAME config be set and be exactly the equal to the host:port that the site is accessed by.

In the test environment that host:port is lando-ui:7777. This commit updates the tests to set that and also updates the click configuration to not set a default SESSION_COOKIE_DOMAIN since that should always be set by whoever is creating the app.