### PR TITLE
Use .test for local development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,8 +24,8 @@ services:
       - OIDC_CLIENT_SECRET=oidc_client_secret_change_me
       - VERSION_PATH=/version.json
       - SECRET_KEY=secret_key_change_me
-      - SESSION_COOKIE_NAME=lando.ui:7777
-      - SESSION_COOKIE_DOMAIN=lando.ui:7777
+      - SESSION_COOKIE_NAME=lando-ui.test:7777
+      - SESSION_COOKIE_DOMAIN=lando-ui.test:7777
       - SESSION_COOKIE_SECURE=0
       - USE_HTTPS=0
   py3-linter:


### PR DESCRIPTION
We can't use '.dev' or '.local' to name hosts for local development.

'.dev' is a TLD and doesn't work under Vagrant (see https://github.com/Varying-Vagrant-Vagrants/VVV/issues/544).

'.local' clashes with MDNS.

According to RFC 6761 '.test' is reserved for local networks, so
let's use that.