### PR TITLE
Lock sass version to 3.4.25

### DIFF
--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -11,7 +11,7 @@ RUN apk del gcc musl-dev libffi-dev python-dev openssl-dev
 
 RUN apk add --update nodejs ruby && rm -rf /var/cache/apk/*
 RUN npm install --global eslint
-RUN gem install sass --no-ri --no-rdoc
+RUN gem install sass --no-ri --no-rdoc -v 3.4.25
 
 # Create a Dockerflow version file at the root so
 # we don't map over it below.


### PR DESCRIPTION
The most recent build of master failed because it could not install the latest sass. As you can see, sass was updated yesterday to 3.5 (https://rubygems.org/gems/sass/versions/3.5.0).
This PR locks sass to a version (3.4.25) that was working previously.