### PR TITLE
Move logging config code / Use Sentry to log application errors

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,8 @@ services:
       - SESSION_COOKIE_SECURE=0
       - USE_HTTPS=0
       - LANDO_API_URL=http://lando-api.test:8888
+      - ENV=localdev
+      - SENTRY_DSN=
   py3-linter:
     build:
       context: ./

--- a/landoui/app.py
+++ b/landoui/app.py
@@ -11,6 +11,7 @@ from flask import Flask
 from flask_assets import Environment
 from flask_talisman import Talisman
 from mozlogging import MozLogFormatter
+from raven.contrib.flask import Sentry
 from webassets.loaders import YAMLLoader
 
 from landoui import auth
@@ -39,19 +40,26 @@ def create_app(
     initialize_logging()
 
     app = Flask(__name__)
-    Talisman(app, content_security_policy=csp, force_https=use_https)
 
     # Set configuration
     app.config['VERSION_PATH'] = version_path
+    log_config_change('VERSION_PATH', version_path)
+
     version_info = json.load(open(version_path))
     logger.info(version_info, 'app.version')
 
+    this_app_version = version_info['version']
+    initialize_sentry(app, this_app_version)
+
+    # Set remaining configuration
     app.config['SECRET_KEY'] = secret_key
     app.config['SESSION_COOKIE_NAME'] = session_cookie_name
     app.config['SESSION_COOKIE_DOMAIN'] = session_cookie_domain
     app.config['SESSION_COOKIE_SECURE'] = session_cookie_secure
     app.config['SERVER_NAME'] = session_cookie_domain
     app.config['USE_HTTPS'] = use_https
+
+    Talisman(app, content_security_policy=csp, force_https=use_https)
 
     # Authentication
     global oidc
@@ -76,6 +84,39 @@ def create_app(
     assets.register(loader.load_bundles())
 
     return app
+
+
+def initialize_sentry(flask_app, release):
+    """Initialize Sentry application monitoring.
+
+    See https://docs.sentry.io/clients/python/advanced/#client-arguments for
+    details about what this function's arguments mean to Sentry.
+
+    Args:
+        flask_app: A Flask() instance.
+        release: A string representing this application release number (such as
+            a git sha).  Will be used as the Sentry "release" identifier. See
+            the Sentry client configuration docs for details.
+    """
+    sentry_dsn = os.environ.get('SENTRY_DSN', None)
+    if sentry_dsn:
+        log_config_change('SENTRY_DSN', sentry_dsn)
+    else:
+        log_config_change('SENTRY_DSN', 'none (sentry disabled)')
+
+    # Do this after logging the DSN so if there is a DSN URL parsing error
+    # the logs will record the configured value before the Sentry client
+    # kills the app.
+    sentry = Sentry(flask_app, dsn=sentry_dsn)
+
+    # Set these attributes directly because their keyword arguments can't be
+    # passed into Sentry.__init__() or make_client().
+    sentry.client.release = release
+    log_config_change('SENTRY_LOG_RELEASE_AS', release)
+
+    environment = os.environ.get('ENV', None)
+    sentry.client.environment = environment
+    log_config_change('SENTRY_LOG_ENVIRONMENT_AS', environment)
 
 
 def initialize_logging():

--- a/landoui/pages.py
+++ b/landoui/pages.py
@@ -7,15 +7,11 @@ import os
 from flask import (
     Blueprint, current_app, jsonify, redirect, render_template, session
 )
-from mozlogging import MozLogFormatter
 
 from landoui.app import oidc
 from landoui.helpers import set_last_local_referrer
 
 logger = logging.getLogger(__name__)
-handler = logging.StreamHandler()
-handler.setFormatter(MozLogFormatter())
-logger.addHandler(handler)
 
 pages = Blueprint('page', __name__)
 pages.before_request(set_last_local_referrer)

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -127,6 +127,14 @@ pycparser==2.17 \
 mozlogging==0.1.0 \
     --hash=sha256:2fc3d520a17b048c8723abdba19f6c01f2bcaf4182944aaac5906f28bd5b7d77 \
     --hash=sha256:2e1362b80418b845164d8d47337da838dade05720dbaf17956d1cafebc511b94
+raven[flask]==6.1.0 \
+    --hash=sha256:56dc9062dd42bca97350e5048ff417c914376366caa3b1b5f788b27ddc0a34b7 \
+    --hash=sha256:02cabffb173b99d860a95d4908e8b1864aad1b8452146e13fd7e212aa576a884
+contextlib2==0.5.5 \
+    --hash=sha256:f5260a6e679d2ff42ec91ec5252f4eeffdcf21053db9113bd0a8e4d953769c00 \
+    --hash=sha256:509f9419ee91cdd00ba34443217d5ca51f5a364a404e1dce9e8979cea969ca48
+blinker==1.4 \
+    --hash=sha256:471aee25f3992bd325afa3772f1063dbdbbca947a041b8b89466dc00d606f8b6
 flask-talisman==0.3.2 \
     --hash=sha256:d7e0773910cfe2cadfa97b01d094fe6e70c5ea4d9f2fe5d3e81c589acf5a0133 \
     --hash=sha256:9945b964f2cce36c036c3d04c665b47c5d05fc923927eae32362384b78e0f08b


### PR DESCRIPTION
Move the log configuration code into the `app` module so that we can log application startup information.

Configure application logging using Sentry.  Boilerplate code was copied from https://github.com/mozilla-conduit/lando-api/pull/26.

Verified working using docker and our real Sentry account.  We should be able to ship this.