### PR TITLE
Tag the latest image in Docker Hub

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -50,3 +50,4 @@ deployment:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
       - "docker tag ${DOCKERHUB_REPO} ${DOCKERHUB_REPO}:${CIRCLE_SHA1}"
       - "docker push ${DOCKERHUB_REPO}:${CIRCLE_SHA1}"
+      - "docker push ${DOCKERHUB_REPO}:latest"


### PR DESCRIPTION
Make the CircleCI build tag and push the 'latest' image tag to Docker
 Hub so that we can use the latest image in the demo.