### PR TITLE
heartbeat-checks-lando-api

### DIFF
--- a/landoui/app.py
+++ b/landoui/app.py
@@ -24,7 +24,7 @@ oidc = None
 
 def create_app(
     version_path, secret_key, session_cookie_name, session_cookie_domain,
-    session_cookie_secure, use_https, enable_asset_pipeline
+    session_cookie_secure, use_https, enable_asset_pipeline, lando_api_url
 ):
     """
     Create an app instance.
@@ -49,6 +49,9 @@ def create_app(
 
     this_app_version = version_info['version']
     initialize_sentry(app, this_app_version)
+
+    app.config['LANDO_API_URL'] = lando_api_url
+    log_config_change('LANDO_API_URL', lando_api_url)
 
     # Set remaining configuration
     app.config['SECRET_KEY'] = secret_key
@@ -109,17 +112,18 @@ def create_app(
 @click.option(
     '--enable-asset-pipeline', envvar='ENABLE_ASSET_PIPELINE', default=1
 )
+@click.option('--lando-api-url', envvar='LANDO_API_URL', default=None)
 def run_dev_server(
     debug, host, port, version_path, secret_key, session_cookie_name,
     session_cookie_domain, session_cookie_secure, use_https,
-    enable_asset_pipeline
+    enable_asset_pipeline, lando_api_url
 ):
     """
     Run the development server which auto reloads when things change.
     """
     app = create_app(
         version_path, secret_key, session_cookie_name, session_cookie_domain,
-        session_cookie_secure, use_https, enable_asset_pipeline
+        session_cookie_secure, use_https, enable_asset_pipeline, lando_api_url
     )
     app.jinja_env.auto_reload = True
     app.config['TEMPLATES_AUTO_RELOAD'] = True

--- a/landoui/assets_app.py
+++ b/landoui/assets_app.py
@@ -20,5 +20,6 @@ app = create_app(
     session_cookie_domain='lando-ui.test',
     session_cookie_secure=False,
     use_https=0,
-    enable_asset_pipeline=True
+    enable_asset_pipeline=True,
+    lando_api_url='lando-api.test',
 )

--- a/landoui/revisions.py
+++ b/landoui/revisions.py
@@ -19,7 +19,7 @@ revisions.before_request(set_last_local_referrer)
 @revisions.route('/revisions/<revision_id>')
 def get_revision(revision_id):
     revision_api_url = '{}/revisions/{}'.format(
-        os.getenv('LANDO_API_URL'), revision_id
+        current_app.config['LANDO_API_URL'], revision_id
     )
 
     try:

--- a/landoui/wsgi.py
+++ b/landoui/wsgi.py
@@ -16,4 +16,5 @@ app = create_app(
     session_cookie_secure=os.getenv('SESSION_COOKIE_SECURE'),
     use_https=int(os.getenv('USE_HTTPS', 1)),
     enable_asset_pipeline=True,
+    lando_api_url=os.getenv('LANDO_API_URL'),
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,13 @@ def disable_log_output():
 
 
 @pytest.fixture
-def app(versionfile, disable_log_output, docker_env_vars):
+def api_url():
+    """A string holding the Lando API base URL. Useful for request mocking."""
+    return 'http://lando-api.test'
+
+
+@pytest.fixture
+def app(versionfile, disable_log_output, docker_env_vars, api_url):
     app = create_app(
         version_path=versionfile.strpath,
         secret_key=str(binascii.b2a_hex(os.urandom(15))),
@@ -35,7 +41,8 @@ def app(versionfile, disable_log_output, docker_env_vars):
         session_cookie_domain='lando-ui.test:7777',
         session_cookie_secure=False,
         use_https=0,
-        enable_asset_pipeline=False
+        enable_asset_pipeline=False,
+        lando_api_url=api_url,
     )
 
     # Turn on the TESTING setting so that exceptions within the app bubble up

--- a/tests/test_dockerflow.py
+++ b/tests/test_dockerflow.py
@@ -4,13 +4,24 @@
 
 import json
 
+import requests
+import requests_mock
+
 
 def test_dockerflow_lb_endpoint_returns_200(client):
     assert client.get('/__lbheartbeat__').status_code == 200
 
 
-def test_dockerflow_heartbeat_endpoint_returns_200(client):
-    assert client.get('/__heartbeat__').status_code == 200
+def test_heartbeat_returns_200_if_lando_api_up(client, api_url):
+    with requests_mock.mock() as m:
+        m.get(api_url + '/__lbheartbeat__', status_code=200)
+        assert client.get('/__heartbeat__').status_code == 200
+
+
+def test_heartbeat_returns_500_if_lando_api_down(client, api_url):
+    with requests_mock.mock() as m:
+        m.get(api_url + '/__lbheartbeat__', exc=requests.ConnectionError)
+        assert client.get('/__heartbeat__').status_code == 500
 
 
 def test_dockerflow_version_endpoint_response(client):

--- a/tests/test_revisions.py
+++ b/tests/test_revisions.py
@@ -7,35 +7,29 @@ import requests_mock
 from tests.canned_responses import LANDO_API_RESPONSE
 
 
-def test_render_valid_revision(client, monkeypatch):
-    monkeypatch.setenv('LANDO_API_URL', 'http://landoapi.test')
+def test_render_valid_revision(client, api_url):
     with requests_mock.mock() as m:
-        m.get('http://landoapi.test/revisions/D1', json=LANDO_API_RESPONSE)
+        m.get(api_url + '/revisions/D1', json=LANDO_API_RESPONSE)
         response = client.get('/revisions/D1')
     assert response.status_code == 200
 
 
-def test_missing_revision_returns_404(client, monkeypatch):
-    monkeypatch.setenv('LANDO_API_URL', 'http://landoapi.test')
+def test_missing_revision_returns_404(client, api_url):
     with requests_mock.mock() as m:
-        m.get('http://landoapi.test/revisions/D1057', status_code=404)
+        m.get(api_url + '/revisions/D1057', status_code=404)
         response = client.get('/revisions/D1057')
     assert response.status_code == 404
 
 
-def test_lando_api_connection_error_returns_500(client, monkeypatch):
-    monkeypatch.setenv('LANDO_API_URL', 'http://landoapi.test')
+def test_lando_api_connection_error_returns_500(client, api_url):
     with requests_mock.mock() as m:
-        m.get(
-            'http://landoapi.test/revisions/D1', exc=requests.ConnectionError
-        )
+        m.get(api_url + '/revisions/D1', exc=requests.ConnectionError)
         response = client.get('/revisions/D1')
     assert response.status_code == 500
 
 
-def test_lando_api_response_insanity_returns_500(client, monkeypatch):
-    monkeypatch.setenv('LANDO_API_URL', 'http://landoapi.test')
+def test_lando_api_response_insanity_returns_500(client, api_url):
     with requests_mock.mock() as m:
-        m.get('http://landoapi.test/revisions/D1', status_code=500)
+        m.get(api_url + '/revisions/D1', status_code=500)
         response = client.get('/revisions/D1')
     assert response.status_code == 500


### PR DESCRIPTION
Make the Lando UI `__heartbeat__` endpoint check Lando API for a valid connection.

This PR includes PR https://github.com/mozilla-conduit/lando-ui/pull/49 to fix test propagation.