### PR TITLE
dockerflow: set cache-control header in responses.

### DIFF
--- a/landoui/dockerflow.py
+++ b/landoui/dockerflow.py
@@ -12,6 +12,15 @@ logger = logging.getLogger(__name__)
 dockerflow = Blueprint('dockerflow', __name__)
 
 
+@dockerflow.after_request
+def disable_caching(response):
+    """Disable caching on a response and return it."""
+    response.cache_control.no_cache = True
+    response.cache_control.no_store = True
+    response.cache_control.must_revalidate = True
+    return response
+
+
 @dockerflow.route('/__heartbeat__')
 def heartbeat():
     """Perform health check of lando-ui.


### PR DESCRIPTION
The dockerflow health and version endpoints should instruct the caller
not to cache any results. This commit sets Cache-Control to properly
disable caching.

Closes #51 