### PR TITLE
stacks: implement a rough ui for the sec-approval workflow (bug 1539289)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       - ENV=localdev
       - SENTRY_DSN=
       - LOG_LEVEL=DEBUG
+      - ENABLE_SEC_APPROVAL=1
   py3-linter:
     build:
       context: ./

--- a/landoui/app.py
+++ b/landoui/app.py
@@ -78,6 +78,8 @@ def create_app(
         _lookup_service_url(lando_api_url, 'phabricator')
     )
     log_config_change('PHABRICATOR_URL', app.config['PHABRICATOR_URL'])
+    app.config['ENABLE_SEC_APPROVAL'] = bool(os.getenv('ENABLE_SEC_APPROVAL'))
+    log_config_change('ENABLE_SEC_APPROVAL', app.config['ENABLE_SEC_APPROVAL'])
 
     # Set remaining configuration
     app.config['SECRET_KEY'] = secret_key

--- a/landoui/forms.py
+++ b/landoui/forms.py
@@ -71,3 +71,8 @@ class UserSettingsForm(FlaskForm):
         ]
     )
     reset_phab_api_token = BooleanField('Delete', default="")
+
+
+class AltCommitMessageForm(FlaskForm):
+    phid = HiddenField("phid")
+    alt_commit_message = StringField("alt_commit_message")

--- a/landoui/forms.py
+++ b/landoui/forms.py
@@ -74,5 +74,6 @@ class UserSettingsForm(FlaskForm):
 
 
 class AltCommitMessageForm(FlaskForm):
+    """Form used to input an alternative commit message for a Revision."""
     phid = HiddenField("phid")
     alt_commit_message = StringField("alt_commit_message")

--- a/landoui/landoapi.py
+++ b/landoui/landoapi.py
@@ -71,11 +71,9 @@ class LandoAPI:
             )
             data = response.json()
         except requests.RequestException as exc:
-            # FIXME this eats the real exception and stack trace!
-            # raise LandoAPICommunicationException(
-            #     "An error occurred when communicating with Lando API"
-            # ) from exc
-            raise
+            raise LandoAPICommunicationException(
+                "An error occurred when communicating with Lando API"
+            ) from exc
         except JSONDecodeError as exc:
             raise LandoAPICommunicationException(
                 "Lando API response could not be decoded as JSON"

--- a/landoui/landoapi.py
+++ b/landoui/landoapi.py
@@ -71,9 +71,11 @@ class LandoAPI:
             )
             data = response.json()
         except requests.RequestException as exc:
-            raise LandoAPICommunicationException(
-                "An error occurred when communicating with Lando API"
-            ) from exc
+            # FIXME this eats the real exception and stack trace!
+            # raise LandoAPICommunicationException(
+            #     "An error occurred when communicating with Lando API"
+            # ) from exc
+            raise
         except JSONDecodeError as exc:
             raise LandoAPICommunicationException(
                 "Lando API response could not be decoded as JSON"

--- a/landoui/templates/stack/partials/security-approval-actions.html
+++ b/landoui/templates/stack/partials/security-approval-actions.html
@@ -1,0 +1,15 @@
+{% if not blockers and use_sec_approval_workflow %}
+  <h1>Security Approval</h1>
+  <p>Set an obfuscated commit message for this revision.</p>
+  <form id="altCommitMessageForm" action="/{{ revision_id }}/commit-message" method="post">
+    {{form.csrf_token}}
+    <div>
+    <p><label for="alt_commit_message">Alternate commit message for
+        revision {{ revision_id }}</label></p>
+    <textarea id="alt_commit_message" name="alt_commit_message" rows="3" cols="70"></textarea>
+    <input type="hidden" name="phid" value="{{ revision_phid }}"/>
+    </div>
+    <button type="submit">Submit</button>
+    <button type="reset">Reset</button>
+  </form>
+{% endif %}

--- a/landoui/templates/stack/partials/security-approval-actions.html
+++ b/landoui/templates/stack/partials/security-approval-actions.html
@@ -1,11 +1,13 @@
 {% if not blockers and use_sec_approval_workflow %}
   <h1>Security Approval</h1>
-  <p>Set an obfuscated commit message for this revision.</p>
+  <p>Revision {{ revision_id }} is a secure revision and should follow the
+      <a href="https://wiki.mozilla.org/Security/Bug_Approval_Process">Security Bug Approval Process</a>.</p>
   <form id="altCommitMessageForm" action="/{{ revision_id }}/commit-message" method="post">
     {{form.csrf_token}}
     <div>
-    <p><label for="alt_commit_message">Alternate commit message for
-        revision {{ revision_id }}</label></p>
+    <p>
+        <label for="alt_commit_message">Please set an obfuscated commit message for revision {{ revision_id }}:</label>
+    </p>
     <textarea id="alt_commit_message" name="alt_commit_message" rows="3" cols="70"></textarea>
     <input type="hidden" name="phid" value="{{ revision_phid }}"/>
     </div>

--- a/landoui/templates/stack/stack.html
+++ b/landoui/templates/stack/stack.html
@@ -98,6 +98,10 @@
   {% endif %}
   </div>
 
+  {% if is_user_authenticated() %}
+    {% include "stack/partials/security-approval-actions.html" %}
+  {% endif %}
+
   <div class="StackPage-actions">
   {% if not is_user_authenticated() %}
     <button disabled>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,7 @@ def docker_env_vars(monkeypatch):
     monkeypatch.setenv('OIDC_CLIENT_ID', 'test_oidc_client_id')
     monkeypatch.setenv('OIDC_CLIENT_SECRET', 'test_oidc_secret')
 
-    # FIXME: this branch needs a comment to explain why we don't use the local env
+    # FIXME: this branch needs a comment to explain why we don't use local env
     if in_circleci():
         import socket
         monkeypatch.setenv('DEBUG', 'True')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,11 +25,13 @@ def docker_env_vars(monkeypatch):
     monkeypatch.setenv('OIDC_CLIENT_ID', 'test_oidc_client_id')
     monkeypatch.setenv('OIDC_CLIENT_SECRET', 'test_oidc_secret')
 
+    # FIXME: this branch needs a comment to explain why we don't use the local env
     if in_circleci():
         import socket
         monkeypatch.setenv('DEBUG', 'True')
         monkeypatch.setenv('HOST', '0.0.0.0')
         monkeypatch.setenv('PORT', '7777')
+        # FIXME: I need this variable set for pytest+pycharm. Set for all envs?
         monkeypatch.setenv(
             'LANDO_API_OIDC_IDENTIFIER', 'lando-api-oidc-identifier'
         )

--- a/tests/test_sec_approval_workflow.py
+++ b/tests/test_sec_approval_workflow.py
@@ -1,11 +1,11 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+import time
 from copy import deepcopy
+from unittest.mock import patch
 
 import pytest
-
-from unittest.mock import patch
 
 pytestmark = pytest.mark.usefixtures("app_config")
 
@@ -75,7 +75,7 @@ def apidouble():
 
 
 @pytest.fixture
-def authenticated_session(client):
+def authenticated_session(client, monkeypatch):
     """Simulate a session for a user who has authenticated with Auth0."""
     # We need to use the session_transaction() method to modify the session
     # in a way that affects both application code and template code sessions.
@@ -90,6 +90,11 @@ def authenticated_session(client):
         session["id_token"] = "foo_id_token"
         session["access_token"] = "foo_access_token"
         session["userinfo"] = {"picture": ""}
+
+        # These two values need to be present in the session for the OIDC
+        # auth library to evaluate the session as fresh and authenticated.
+        session["id_token_jwt"] = "foo_jwt"
+        session["last_authenticated"] = time.time()
 
 
 @pytest.fixture

--- a/tests/test_sec_approval_workflow.py
+++ b/tests/test_sec_approval_workflow.py
@@ -1,0 +1,180 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from unittest.mock import patch
+
+pytestmark = pytest.mark.usefixtures("app_config")
+
+# A fake lando-api response that contains the minimum data necessary to render the
+# lando front-page template.
+STACK_RESPONSE = {
+    "edges": [],
+    "landable_paths": [["PHID-DREV-phoo"]],
+    "revisions": [
+        {
+            "phid": "PHID-DREV-phoo",
+            "id": "D1",
+            "diff": {"id": 1, "author": "Wobble"},
+            "repo_phid": "PHID-REPO-repo",
+            "status": {
+                "closed": False,
+                "display": "Needs Review",
+                "value": "needs-review",
+            },
+        }
+    ],
+    "repositories": [],
+}
+
+
+class StubLandoAPIRequest:
+    """Stub for the LandoAPI object's .request() method.
+
+    Meant to replace the real object's method using unittest.patch() or
+    pytest monkeypatch.
+    """
+
+    def __init__(self, transplant_dryrun_response=None):
+        """
+        Args:
+            transplant_dryrun_response: Optional response data to return from calls
+                to the LandoAPI /transplants/dryrun operation.  Default: {}
+        """
+        self.transplant_dryrun_response = transplant_dryrun_response or {}
+
+    def __call__(self, real_object_self, operation, *args, **kwargs):
+        """A replacement for LandoAPI.request().
+
+        Knows how to return canned responses for the various operations
+        against Lando API necessary to render a page on the site.
+        """
+        if operation.startswith("stacks"):
+            return STACK_RESPONSE
+        elif operation == "transplants":
+            return {}
+        elif operation == "transplants/dryrun":
+            return self.transplant_dryrun_response
+        else:
+            raise RuntimeError(
+                "The API method for {} is not implemented by this stub".format(
+                    operation
+                )
+            )
+
+
+@pytest.fixture
+def app_config(app):
+    app.config["ENABLE_SEC_APPROVAL"] = True
+
+
+@pytest.fixture
+def authenticated_session(client):
+    """Simulate a session for a user who has authenticated with Auth0."""
+    # We need to use the session_transaction() method to modify the session
+    # in a way that affects both application code and template code sessions.
+    #
+    # If we only modify the session global then the global session object will be
+    # modified but the template session object will be blank.
+    #
+    # Note: unfortunately the session object in the current process is still blank
+    # so we can't test if landoui.helpers.is_user_authenticated() == True.
+    with client.session_transaction() as session:
+        session["id_token"] = "foo_id_token"
+        session["access_token"] = "foo_access_token"
+        session["userinfo"] = {"picture": ""}
+
+
+@pytest.fixture
+def anonymous_session(client):
+    """Simulate a session for an unauthenticated (anonymous) user."""
+    # We need to use the session_transaction() method to modify the session
+    # in a way that affects both application code and template code sessions.
+    #
+    # If we only modify the session global then the global session object will be
+    # modified but the template session object will be blank.
+    #
+    # Note: unfortunately the session object in the current process is still blank
+    # so we can't test if landoui.helpers.is_user_authenticated() == False.
+    with client.session_transaction() as session:
+        assert not session.keys()  # Check just to be sure.
+
+
+def test_view_stack_not_logged_in(client, anonymous_session):
+    # Basic happy-path test for an anonymous user.
+    with patch("landoui.landoapi.LandoAPI.request") as api:
+        api.side_effect = StubLandoAPIRequest()
+
+        rv = client.get("/D1/")
+
+        assert rv.status_code == 200
+
+
+def test_view_stack_logged_in(client, authenticated_session):
+    # Basic happy-path test for a logged in user.
+    with patch("landoui.landoapi.LandoAPI.request") as api:
+        api.side_effect = StubLandoAPIRequest()
+
+        rv = client.get("/D1/")
+
+        assert rv.status_code == 200
+
+
+def test_sec_approval_form_shown_if_path_has_force_feature_flag(
+    client, authenticated_session
+):
+    with patch("landoui.landoapi.LandoAPI.request") as api:
+        api.side_effect = StubLandoAPIRequest()
+
+        rv = client.get("/D1/?treat_as_secure")
+
+        assert rv.status_code == 200
+        assert b'id="altCommitMessageForm"' in rv.data
+
+
+def test_sec_approval_form_hidden_if_no_secure_revisions_in_stack(
+    client, authenticated_session
+):
+    with patch("landoui.landoapi.LandoAPI.request") as api:
+        api.side_effect = StubLandoAPIRequest()
+
+        rv = client.get("/D1/")
+
+        assert rv.status_code == 200
+        assert b'id="altCommitMessageForm"' not in rv.data
+
+
+def test_sec_approval_form_shown_if_secure_revisions_in_stack(
+    client, authenticated_session
+):
+    transplant_dryrun_response = {"secureRevisions": ["PHID-DREV-phoo"]}
+
+    with patch("landoui.landoapi.LandoAPI.request") as api:
+        api.side_effect = StubLandoAPIRequest(transplant_dryrun_response)
+
+        rv = client.get("/D1/")
+
+        assert rv.status_code == 200
+        assert b'id="altCommitMessageForm"' in rv.data
+
+
+def test_submit_alt_commit_messages(app, client, authenticated_session):
+    revision_phid = "PHID-DREV-phoo"
+    transplant_dryrun_response = {"secureRevisions": [revision_phid]}
+
+    # Disable CSRF protection so we can submit forms without tokens.
+    app.config["WTF_CSRF_ENABLED"] = False
+
+    with patch("landoui.landoapi.LandoAPI.request") as api:
+        api.side_effect = StubLandoAPIRequest(transplant_dryrun_response)
+
+        formdata = {
+            "phid": revision_phid,
+            "alt_commit_message": "s3cr3t",
+        }
+        rv = client.post("/D1/commit-message", data=formdata, follow_redirects=True)
+
+        assert rv.status_code == 200
+        assert b's3cr3t' in rv.data

--- a/tests/test_sec_approval_workflow.py
+++ b/tests/test_sec_approval_workflow.py
@@ -1,6 +1,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+from copy import deepcopy
 
 import pytest
 
@@ -8,60 +9,54 @@ from unittest.mock import patch
 
 pytestmark = pytest.mark.usefixtures("app_config")
 
-# A fake lando-api response that contains the minimum data necessary to render the
-# lando front-page template.
-STACK_RESPONSE = {
-    "edges": [],
-    "landable_paths": [["PHID-DREV-phoo"]],
-    "revisions": [
-        {
-            "phid": "PHID-DREV-phoo",
-            "id": "D1",
-            "diff": {"id": 1, "author": "Wobble"},
-            "repo_phid": "PHID-REPO-repo",
-            "status": {
-                "closed": False,
-                "display": "Needs Review",
-                "value": "needs-review",
-            },
-        }
-    ],
-    "repositories": [],
-}
 
+class LandoAPIDouble:
+    """Returns canned responses for LandoAPI.request()"""
 
-class StubLandoAPIRequest:
-    """Stub for the LandoAPI object's .request() method.
+    # A fake lando-api response that contains the minimum data necessary to
+    # render the lando front-page template.
+    default_stack_response = {
+        "edges": [],
+        "landable_paths": [["PHID-DREV-phoo"]],
+        "revisions": [
+            {
+                "phid": "PHID-DREV-phoo",
+                "id": "D1",
+                "diff": {
+                    "id": 1,
+                    "author": "Wobble"
+                },
+                "repo_phid": "PHID-REPO-repo",
+                "status": {
+                    "closed": False,
+                    "display": "Needs Review",
+                    "value": "needs-review",
+                },
+                "is_secure": False,
+            }
+        ],
+        "repositories": [],
+    }
 
-    Meant to replace the real object's method using unittest.patch() or
-    pytest monkeypatch.
-    """
+    def __init__(self):
+        self.stack_response = deepcopy(self.default_stack_response)
 
-    def __init__(self, transplant_dryrun_response=None):
-        """
-        Args:
-            transplant_dryrun_response: Optional response data to return from calls
-                to the LandoAPI /transplants/dryrun operation.  Default: {}
-        """
-        self.transplant_dryrun_response = transplant_dryrun_response or {}
-
-    def __call__(self, real_object_self, operation, *args, **kwargs):
+    def __call__(self, patched_object_self, operation, *args, **kwargs):
         """A replacement for LandoAPI.request().
 
         Knows how to return canned responses for the various operations
         against Lando API necessary to render a page on the site.
         """
         if operation.startswith("stacks"):
-            return STACK_RESPONSE
+            return self.stack_response
         elif operation == "transplants":
             return {}
         elif operation == "transplants/dryrun":
-            return self.transplant_dryrun_response
+            return {}
         else:
             raise RuntimeError(
-                "The API method for {} is not implemented by this stub".format(
-                    operation
-                )
+                "The API method for {} is not implemented by this stub".
+                format(operation)
             )
 
 
@@ -71,16 +66,26 @@ def app_config(app):
 
 
 @pytest.fixture
+def apidouble():
+    """Patch lando-api to return stub responses."""
+    stub = LandoAPIDouble()
+    with patch("landoui.landoapi.LandoAPI.request") as api:
+        api.side_effect = stub
+        yield stub
+
+
+@pytest.fixture
 def authenticated_session(client):
     """Simulate a session for a user who has authenticated with Auth0."""
     # We need to use the session_transaction() method to modify the session
     # in a way that affects both application code and template code sessions.
     #
-    # If we only modify the session global then the global session object will be
-    # modified but the template session object will be blank.
+    # If we only modify the session global then the global session object
+    # will be modified but the template session object will be blank.
     #
-    # Note: unfortunately the session object in the current process is still blank
-    # so we can't test if landoui.helpers.is_user_authenticated() == True.
+    # Note: unfortunately the session object in the current process is still
+    # blank so we can't test if landoui.helpers.is_user_authenticated() ==
+    # True.
     with client.session_transaction() as session:
         session["id_token"] = "foo_id_token"
         session["access_token"] = "foo_access_token"
@@ -93,88 +98,53 @@ def anonymous_session(client):
     # We need to use the session_transaction() method to modify the session
     # in a way that affects both application code and template code sessions.
     #
-    # If we only modify the session global then the global session object will be
-    # modified but the template session object will be blank.
+    # If we only modify the session global then the global session object
+    # will be modified but the template session object will be blank.
     #
-    # Note: unfortunately the session object in the current process is still blank
-    # so we can't test if landoui.helpers.is_user_authenticated() == False.
+    # Note: unfortunately the session object in the current process is still
+    # blank so we can't test if landoui.helpers.is_user_authenticated() ==
+    # False.
     with client.session_transaction() as session:
         assert not session.keys()  # Check just to be sure.
 
 
-def test_view_stack_not_logged_in(client, anonymous_session):
+def test_view_stack_not_logged_in(client, anonymous_session, apidouble):
     # Basic happy-path test for an anonymous user.
-    with patch("landoui.landoapi.LandoAPI.request") as api:
-        api.side_effect = StubLandoAPIRequest()
-
-        rv = client.get("/D1/")
-
-        assert rv.status_code == 200
+    rv = client.get("/D1/")
+    assert rv.status_code == 200
 
 
-def test_view_stack_logged_in(client, authenticated_session):
+def test_view_stack_logged_in(client, authenticated_session, apidouble):
     # Basic happy-path test for a logged in user.
-    with patch("landoui.landoapi.LandoAPI.request") as api:
-        api.side_effect = StubLandoAPIRequest()
-
-        rv = client.get("/D1/")
-
-        assert rv.status_code == 200
+    rv = client.get("/D1/")
+    assert rv.status_code == 200
 
 
-def test_sec_approval_form_shown_if_path_has_force_feature_flag(
-    client, authenticated_session
+def test_sec_approval_form_hidden_if_current_revision_is_public(
+    client, authenticated_session, apidouble
 ):
-    with patch("landoui.landoapi.LandoAPI.request") as api:
-        api.side_effect = StubLandoAPIRequest()
-
-        rv = client.get("/D1/?treat_as_secure")
-
-        assert rv.status_code == 200
-        assert b'id="altCommitMessageForm"' in rv.data
+    rv = client.get("/D1/")
+    assert rv.status_code == 200
+    assert b'id="altCommitMessageForm"' not in rv.data
 
 
-def test_sec_approval_form_hidden_if_no_secure_revisions_in_stack(
-    client, authenticated_session
+def test_sec_approval_form_shown_if_current_revision_is_secure(
+    client, authenticated_session, apidouble
 ):
-    with patch("landoui.landoapi.LandoAPI.request") as api:
-        api.side_effect = StubLandoAPIRequest()
-
-        rv = client.get("/D1/")
-
-        assert rv.status_code == 200
-        assert b'id="altCommitMessageForm"' not in rv.data
+    apidouble.stack_response["revisions"][0]["is_secure"] = True
+    rv = client.get("/D1/")
+    assert rv.status_code == 200
+    assert b'id="altCommitMessageForm"' in rv.data
 
 
-def test_sec_approval_form_shown_if_secure_revisions_in_stack(
-    client, authenticated_session
-):
-    transplant_dryrun_response = {"secureRevisions": ["PHID-DREV-phoo"]}
-
-    with patch("landoui.landoapi.LandoAPI.request") as api:
-        api.side_effect = StubLandoAPIRequest(transplant_dryrun_response)
-
-        rv = client.get("/D1/")
-
-        assert rv.status_code == 200
-        assert b'id="altCommitMessageForm"' in rv.data
-
-
-def test_submit_alt_commit_messages(app, client, authenticated_session):
-    revision_phid = "PHID-DREV-phoo"
-    transplant_dryrun_response = {"secureRevisions": [revision_phid]}
-
+def test_submit_alt_commit_message(app, client, authenticated_session):
     # Disable CSRF protection so we can submit forms without tokens.
     app.config["WTF_CSRF_ENABLED"] = False
 
-    with patch("landoui.landoapi.LandoAPI.request") as api:
-        api.side_effect = StubLandoAPIRequest(transplant_dryrun_response)
+    formdata = {"phid": "PHID-DREV-phoo", "alt_commit_message": "s3cr3t"}
+    rv = client.post(
+        "/D1/commit-message", data=formdata, follow_redirects=True
+    )
 
-        formdata = {
-            "phid": revision_phid,
-            "alt_commit_message": "s3cr3t",
-        }
-        rv = client.post("/D1/commit-message", data=formdata, follow_redirects=True)
-
-        assert rv.status_code == 200
-        assert b's3cr3t' in rv.data
+    assert rv.status_code == 200
+    assert b"s3cr3t" in rv.data


### PR DESCRIPTION
Consume sec-approval workflow-related messages from lando-api and
display sec-approval workflow-related pages in response.

The feature is protected behind a new feature flag.

The UI for inputting an alternate commit message is a rough draft.
The code does not communicate the new commit message back to lando-api.