### PR TITLE
[sec-approval/1] add a sec-approval workflow feature flag (bug 1550013)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       - ENV=localdev
       - SENTRY_DSN=
       - LOG_LEVEL=DEBUG
+      - ENABLE_SEC_APPROVAL=1
   py3-linter:
     build:
       context: ./

--- a/landoui/app.py
+++ b/landoui/app.py
@@ -78,6 +78,8 @@ def create_app(
         _lookup_service_url(lando_api_url, 'phabricator')
     )
     log_config_change('PHABRICATOR_URL', app.config['PHABRICATOR_URL'])
+    app.config['ENABLE_SEC_APPROVAL'] = bool(os.getenv('ENABLE_SEC_APPROVAL'))
+    log_config_change('ENABLE_SEC_APPROVAL', app.config['ENABLE_SEC_APPROVAL'])
 
     # Set remaining configuration
     app.config['SECRET_KEY'] = secret_key

--- a/landoui/revisions.py
+++ b/landoui/revisions.py
@@ -52,8 +52,8 @@ def annotate_sec_approval_workflow_info(revisions):
     See https://wiki.mozilla.org/Security/Bug_Approval_Process
 
     Args:
-        revisions: A dict of (phid, revision_data) items. The dict will have new keys
-            added to it by this function.
+        revisions: A dict of (phid, revision_data) items. The dict will have
+            new keys added to it by this function.
     """
     for revision in revisions.values():
         if current_app.config.get("ENABLE_SEC_APPROVAL"):

--- a/landoui/templates/stack/stack.html
+++ b/landoui/templates/stack/stack.html
@@ -33,7 +33,7 @@
       <tbody>
       {% for phid, drawing in rows %}
         {% set revision = revisions[phid] %}
-        {% if use_sec_approval_workflow %}
+        {% if revision['should_use_sec_approval_workflow'] %}
           <!-- This revision is subject to the sec-approval workflow -->
         {% endif %}
         <tr

--- a/landoui/templates/stack/stack.html
+++ b/landoui/templates/stack/stack.html
@@ -33,6 +33,9 @@
       <tbody>
       {% for phid, drawing in rows %}
         {% set revision = revisions[phid] %}
+        {% if use_sec_approval_workflow %}
+          <!-- This revision is subject to the sec-approval workflow -->
+        {% endif %}
         <tr
           class="StackPage-revision{%
             if series and phid in series %} StackPage-revision-in-series{% endif


### PR DESCRIPTION
Add a feature flag to turn the sec-approval workflow on and off. We
verify the flag is working by adding a comment to the HTML document if
the feature is turned on and the revision is secure.