### PR TITLE
tests: tell YAPF to ignore the .git directory

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -38,7 +38,7 @@ def lint_flake8(ctx):
 def lint_yapf(ctx):
     """Run yapf."""
     run(
-        'docker-compose run --rm py3-linter yapf --diff --recursive ./',
+        'docker-compose run --rm py3-linter yapf --diff --recursive --exclude=\'./.git/*\' ./',  # noqa
         pty=USE_PTY,
         echo=True
     )

--- a/tests/test_py3_codequality.py
+++ b/tests/test_py3_codequality.py
@@ -9,7 +9,7 @@ import subprocess
 
 def test_check_python_style():
     files = ('./', )
-    cmd = ('yapf', '--diff', '--recursive')
+    cmd = ('yapf', '--diff', '--recursive', '--exclude', './.git/*')
     passed = len(subprocess.check_output(cmd + files)) == 0
     assert passed, 'The python code does not adhear to the project style.'
 


### PR DESCRIPTION
YAPF will happily check the style of all files in the .git directory.
This causes our test suite to fail if a third party tool puts something
in .git that doesn't match our project's code style. YAPF should just
ignore .git/.