### PR TITLE
ui: add a form for requesting sec-approval (bug 1550013)

### DIFF
--- a/landoui/assets_src/css/pages/StackPage.scss
+++ b/landoui/assets_src/css/pages/StackPage.scss
@@ -245,7 +245,6 @@ ul.StackPage-blockers {
     white-space: pre-wrap;
     height: auto;
     line-height: 1.25em;
-    padding: 0;
     margin-top: 1ch;
     margin-left: 1ch;
     color: inherit;
@@ -291,6 +290,30 @@ ul.StackPage-blockers {
   &-landingTo {
     font-weight: normal;
   }
+
+  &-secureRevisionWarning {
+    background: #FEDBDB;
+    margin: 1ch 0 0 1ch;
+    padding: 1em;
+    position: relative;
+  }
+
+  &-editMessagePanel {
+    display: none;
+    background: #FEDBDB;
+    margin: 0 0 4px 1ch;
+    padding: 1em;
+
+    &-foot {
+      padding-top: 20px;
+    }
+
+    label {
+      display: block;
+      margin-bottom: 0.5em;
+      font-weight: bold;
+    }
+  }
 }
 
 .StackPage-timeline {
@@ -301,7 +324,7 @@ ul.StackPage-blockers {
   }
 }
 
-.StackPage-errors {
+%error-message {
   background: #E8A2A2;
   border: 1px solid #A53030;
   color:#A53030;
@@ -312,4 +335,15 @@ ul.StackPage-blockers {
     list-style: disc outside;
     margin-left: 2em;
   }
+}
+
+.StackPage-errors {
+  @extend %error-message;
+}
+
+.StackPage-landingPreview-editMessagePanel-formErrors {
+  @extend %error-message;
+  display: none;
+  margin-top: 0.5em;
+  width: 123ch;
 }

--- a/landoui/assets_src/js/components/LandingPreview.js
+++ b/landoui/assets_src/js/components/LandingPreview.js
@@ -62,40 +62,147 @@ $.fn.landingPreview = function() {
       }
     };
 
+    let swapDisplayEditPanels = ($displayMessagePanel, $editMessagePanel) => {
+      if($editMessagePanel.data('expanded')) {
+        $displayMessagePanel.show();
+        $editMessagePanel.hide();
+        $editMessagePanel.data('expanded', false);
+      } else {
+        $displayMessagePanel.hide();
+        $editMessagePanel.show();
+        $editMessagePanel.data('expanded', true);
+      }
+    };
+
+    let submitSecApprovalForm = ($form, $error_list) => {
+        const data = new FormData($form[0]);
+
+        fetch('/request-sec-approval', {
+          method: 'POST',
+          headers: {'Accept': 'application/json'},
+          body: data,
+        })
+          .then(response => {
+            if (response.ok || response.status === 400 || response.status === 401) {
+              // The submission succeeded or failed with a validation error.
+              return response.json();
+            } else {
+              // The submission failed with a network or server error.
+              return Promise.reject(
+                new Error("Bad response for form submission: " + response.status)
+              );
+            }
+          })
+          .then(json => {
+            const errors = json.errors;
+
+            if (errors) {
+              // We got a form submission validation error.
+              console.info("sec-approval form submission failed");
+
+              // Overwrite the list of form errors.
+              $error_list.empty();
+              // The data structure with form errors is:
+              //  {
+              //    field_1: [error_msg_1, error_msg_2, ...],
+              //    field_2: [error_msg_1, error_msg_2, ...],
+              //    ...
+              //  }
+              Object.keys(errors).forEach(field => {
+                errors[field].forEach(error => {
+                  $('<li>', {
+                    text: error
+                  }).appendTo($error_list);
+                });
+              });
+
+              $error_list.show();
+
+            } else {
+              // Submission was OK, reload the page and show the "Success" dialog.
+              console.info("sec-approval form submission succeeded");
+              let url = new URL(document.URL);
+              url.searchParams.set('show_approval_success', data.get('revision_id'));
+              document.location.assign(url.toString());
+            }
+          })
+          .catch(err => { console.error(err) });
+    };
+
+
     let longMessages = 0;
 
     $revisions.each(function () {
       let $revision = $(this);
+
+      // Message display
+      let $displayMsgPanel = $revision.find('.StackPage-landingPreview-displayMessagePanel');
       let $toggleButton = $revision.find('.StackPage-landingPreview-expand');
       let $commitMessage = $revision.find('.StackPage-landingPreview-commitMessage');
       let $seeMore = $revision.find('.StackPage-landingPreview-seeMore');
       let lines = $commitMessage.text().split(/\r\n|\r|\n/).length;
 
+      // Message editing
+      let $editMessageBtn = $revision.find('.StackPage-landingPreview-editMessage');
+      let $editMsgPanel = $revision.find('.StackPage-landingPreview-editMessagePanel');
+      let $editMsgForm = $revision.find('form');
+      let $editMsgFormErrorsList = $editMsgForm.find('.StackPage-landingPreview-editMessagePanel-formErrors')
+
+      ///////////////////////////
+      //
+      // Message display routines
+      //
+      ///////////////////////////
+
       if (lines <= 5){
         $toggleButton.hide();
-        return;
+      } else {
+        // Handle long commit messages.
+
+        longMessages++;
+
+        // Sets up the display of how many lines are hidden:
+        // expandCommitMessage and collapseCommitMessage merely toggle this when clicked.
+        $toggleButton.text('Show all ' + lines + ' lines');
+        $seeMore.text('... (' + (lines - 5) + ' more lines)');
+
+        $toggleButton.on('click', (e) => {
+          e.preventDefault();
+          toggleCommitMessage($commitMessage, $seeMore, $toggleButton, lines);
+        });
+
+        $expandAllButton.on('click', (e) => {
+          e.preventDefault();
+          expandCommitMessage($commitMessage, $seeMore, $toggleButton, lines);
+        });
+
+        $collapseAllButton.on('click', (e) => {
+          e.preventDefault();
+          collapseCommitMessage($commitMessage, $seeMore, $toggleButton, lines)
+        });
       }
 
-      longMessages++;
+      ///////////////////////////
+      //
+      // Message editing routines
+      //
+      ///////////////////////////
 
-      // Sets up the display of how many lines are hidden:
-      // expandCommitMessage and collapseCommitMessage merely toggle this when clicked.
-      $toggleButton.text('Show all ' + lines + ' lines');
-      $seeMore.text('... (' + (lines - 5) + ' more lines)');
-
-      $toggleButton.on('click', (e) => {
+      $editMessageBtn.on('click', (e) => {
         e.preventDefault();
-        toggleCommitMessage($commitMessage, $seeMore, $toggleButton, lines);
+        $editMessageBtn.attr({'disabled': true});
+        swapDisplayEditPanels($displayMsgPanel, $editMsgPanel);
       });
 
-      $expandAllButton.on('click', (e) => {
+      $editMsgForm.on('submit', (e) => {
         e.preventDefault();
-        expandCommitMessage($commitMessage, $seeMore, $toggleButton, lines);
+        submitSecApprovalForm($editMsgForm, $editMsgFormErrorsList);
       });
 
-      $collapseAllButton.on('click', (e) => {
+      $editMsgForm.on('reset', (e) => {
         e.preventDefault();
-        collapseCommitMessage($commitMessage, $seeMore, $toggleButton, lines)
+        $editMessageBtn.attr({'disabled': false});
+        swapDisplayEditPanels($displayMsgPanel, $editMsgPanel);
       });
     });
 
@@ -103,7 +210,6 @@ $.fn.landingPreview = function() {
       $expandAllButton.css('display', 'none');
       $collapseAllButton.css('display', 'none');
     }
-
 
     $previewButton.on('click', (e) => {
       e.preventDefault();

--- a/landoui/assets_src/js/components/RequestSubmitted.js
+++ b/landoui/assets_src/js/components/RequestSubmitted.js
@@ -1,0 +1,20 @@
+'use strict';
+
+$.fn.secRequestSubmitted = function() {
+  return this.each(function() {
+    let $modal = $(this);
+    let $closeBtn = $modal.find('.StackPage-secRequestSubmitted-close');
+
+    $closeBtn.on('click', e => {
+      e.preventDefault();
+      $modal.removeClass('is-active');
+    });
+
+    $(document).ready(() => {
+      let url = new URL(document.URL);
+      if (url.searchParams.has('show_approval_success')) {
+        $modal.addClass('is-active');
+      }
+    });
+  });
+};

--- a/landoui/assets_src/js/main.js
+++ b/landoui/assets_src/js/main.js
@@ -4,10 +4,12 @@ $(document).ready(function() {
   let $timeline = $('.StackPage-timeline');
   let $landingPreview = $('.StackPage-landingPreview');
   let $stack = $('.StackPage-stack');
+  let $secRequestSubmitted = $('.StackPage-secRequestSubmitted');
 
   // Initialize components
   $('.Navbar').landoNavbar();
   $timeline.timeline();
   $landingPreview.landingPreview();
   $stack.stack();
+  $secRequestSubmitted.secRequestSubmitted();
 });

--- a/landoui/forms.py
+++ b/landoui/forms.py
@@ -5,7 +5,8 @@ import json
 from json.decoder import JSONDecodeError
 
 from flask_wtf import FlaskForm
-from wtforms import BooleanField, HiddenField, StringField, ValidationError
+from wtforms import BooleanField, HiddenField, StringField, TextAreaField, \
+    ValidationError
 from wtforms.validators import InputRequired, optional, Regexp
 
 
@@ -59,6 +60,24 @@ class TransplantRequestForm(FlaskForm):
         ],
     )
     confirmation_token = HiddenField('confirmation_token')
+
+
+class SecApprovalRequestForm(FlaskForm):
+    new_message = TextAreaField(
+        'new_message',
+        validators=[
+            InputRequired(message='A valid commit message must be provided'),
+        ]
+    )
+    revision_id = StringField(
+        'revision_id',
+        validators=[
+            InputRequired(
+                message='A valid Revision monogram must be provided'
+            ),
+            Regexp("^D[0-9]+$"),
+        ]
+    )
 
 
 class UserSettingsForm(FlaskForm):

--- a/landoui/templates/stack/partials/landing-preview.html
+++ b/landoui/templates/stack/partials/landing-preview.html
@@ -43,10 +43,45 @@
         </div>
         <button class="StackPage-landingPreview-expand button"></button>
       </div>
-      <pre class="StackPage-landingPreview-commitMessage">{{
+      {% if revision['should_use_sec_approval_workflow'] %}
+      <div class="StackPage-landingPreview-secureRevisionWarning">
+        <p>
+          <strong>Warning:</strong> This is a secure revision and should follow the
+          <a href="">Security Bug Approval Process</a>.
+        </p>
+        <p>
+          You should consider editing the commit message so that it does not leak
+          security-sensitive information into the Mozilla source repositories.
+        </p>
+        <button class="StackPage-landingPreview-editMessage button">Edit Commit Message</button>
+      </div>
+      {% endif %}
+      <div class="StackPage-landingPreview-displayMessagePanel">
+        <pre class="StackPage-landingPreview-commitMessage">{{
         revision['commit_message']|escape_html|linkify_bug_numbers|linkify_revision_urls|safe
       }}</pre>
-      <div class="StackPage-landingPreview-seeMore"></div>
+        <div class="StackPage-landingPreview-seeMore"></div>
+      </div>
+      <div class="StackPage-landingPreview-editMessagePanel">
+        <form action="/request-sec-approval" method="post">
+          {{sec_approval_form.csrf_token}}
+          <input type="hidden" name="revision_id" value="{{ revision['id'] }}" />
+          <label for="new_message">New commit message:</label>
+<textarea
+        cols="120"
+        rows="5"
+        name="new_message"
+>{{ revision['title']|safe }}
+
+{{ revision['summary']|safe}}</textarea>
+          <ul class="StackPage-landingPreview-editMessagePanel-formErrors">
+          </ul>
+          <div class="StackPage-landingPreview-editMessagePanel-foot">
+            <button type="submit" class="button">Submit For Approval</button>
+            <button type="reset" class="StackPage-landingPreview-cancelMsgEditBtn button">Cancel</button>
+          </div>
+        </form>
+      </div>
     </div>
   {% endfor %}
   </div>

--- a/landoui/templates/stack/stack.html
+++ b/landoui/templates/stack/stack.html
@@ -33,9 +33,6 @@
       <tbody>
       {% for phid, drawing in rows %}
         {% set revision = revisions[phid] %}
-        {% if revision['should_use_sec_approval_workflow'] %}
-          <!-- This revision is subject to the sec-approval workflow -->
-        {% endif %}
         <tr
           class="StackPage-revision{%
             if series and phid in series %} StackPage-revision-in-series{% endif
@@ -120,21 +117,21 @@
   </div>
 
   {% if is_user_authenticated() %}
-  <form class="StackPage-form" action="" method="post">
-    {{form.csrf_token}}
-    {{form.landing_path}}
-    {{form.confirmation_token}}
-    <div class="StackPage-landingPreview modal">
-      <div class="modal-background"></div>
-      <div class="modal-card">
-        <header class="modal-card-head">
-          <p class="modal-card-title">Preview landing</p>
-          <button class="StackPage-landingPreview-close delete" aria-label="close"></button>
-        </header>
-        <section class="modal-card-body">
-          {% include "stack/partials/landing-preview.html" %}
-        </section>
-        <footer class="modal-card-foot">
+  <div class="StackPage-landingPreview modal">
+    <div class="modal-background"></div>
+    <div class="modal-card">
+      <header class="modal-card-head">
+        <p class="modal-card-title">Preview landing</p>
+        <button class="StackPage-landingPreview-close delete" aria-label="close"></button>
+      </header>
+      <section class="modal-card-body">
+        {% include "stack/partials/landing-preview.html" %}
+      </section>
+      <footer class="modal-card-foot">
+        <form class="StackPage-form" action="" method="post">
+          {{form.csrf_token}}
+          {{form.landing_path}}
+          {{form.confirmation_token}}
           <button
               class="StackPage-landingPreview-land button"
               data-target-repo="{{ target_repo['url']|repo_path }}"
@@ -142,12 +139,28 @@
             Land to {{ target_repo['url']|repo_path }}
           </button>
           <button class="StackPage-landingPreview-close button">Cancel</button>
-        </footer>
-      </div>
+        </form>
+      </footer>
     </div>
-  </form>
+  </div>
   {% endif %}
 
+  <div class="StackPage-secRequestSubmitted modal">
+    <div class="modal-background"></div>
+    <div class="modal-card">
+      <header class="modal-card-head">
+        <p class="modal-card-title">Request submitted</p>
+        <button class="StackPage-secRequestSubmitted-close delete" aria-label="close"></button>
+      </header>
+      <section class="modal-card-body">
+        <p>Your request for review by the sec-approval team has been submitted.</p>
+        <p><a href="{{ submitted_rev_url }}">View my request in Phabricator</a></p>
+      </section>
+      <footer class="modal-card-foot">
+        <button class="StackPage-secRequestSubmitted-close button" aria-label="close">Close</button>
+      </footer>
+    </div>
+  </div>
 
 </main>
 {% endblock %}

--- a/tests/test_sec_approval_workflow.py
+++ b/tests/test_sec_approval_workflow.py
@@ -7,6 +7,8 @@ from unittest.mock import patch
 
 import pytest
 
+SEC_APPROVAL_HTML_MARK = b'<div class="StackPage-landingPreview-secureRevisionWarning">'  # noqa
+
 LANDO_API_STACK = {
     "revisions": [
         {
@@ -139,7 +141,7 @@ def apidouble():
 
 
 @pytest.fixture
-def authenticated_session(client, monkeypatch):
+def authenticated_session(client):
     """Simulate a session for a user who has authenticated with Auth0."""
     # We need to use the session_transaction() method to modify the session
     # in a way that affects both application code and template code sessions.
@@ -180,10 +182,7 @@ def anonymous_session(client):
 def sec_approval_revision_in_page(rv) -> bool:
     """Does the given response contain a sec-approval revision in its content?
     """
-    return (
-        b"<!-- This revision is subject to the sec-approval workflow -->" in
-        rv.data
-    )
+    return SEC_APPROVAL_HTML_MARK in rv.data
 
 
 def test_view_stack_not_logged_in(client, anonymous_session, apidouble):


### PR DESCRIPTION
Add a form for requesting sec-approval for a revision's commit message.
 Reorganize the Land Preview forms to accommodate the new sec-approval
 form. Add a dummy HTTP endpoint to accept requests from the new form.