### PR TITLE
app: add ops-friendly app startup message

### DIFF
--- a/landoui/app.py
+++ b/landoui/app.py
@@ -128,6 +128,7 @@ def create_app(
         )
         assets.register(loader.load_bundles())
 
+    logger.info("Application started successfully.")
     return app
 
 


### PR DESCRIPTION
Log an Ops-friendly message after the application starts successfully.
