### PR TITLE
landing-preview: fix landing button not working in Safari or Chrome (bug 1570960)

### DIFF
--- a/landoui/assets_src/js/components/LandingPreview.js
+++ b/landoui/assets_src/js/components/LandingPreview.js
@@ -3,6 +3,7 @@
 $.fn.landingPreview = function() {
   return this.each(function() {
     let $landingPreview = $(this);
+    let $form = $('.StackPage-form');
     let $close = $landingPreview.find('.StackPage-landingPreview-close');
     let $warnings = $landingPreview.find('.StackPage-landingPreview-warnings input[type=checkbox]');
     let $blocker = $landingPreview.find('.StackPage-landingPreview-blocker');
@@ -34,7 +35,7 @@ $.fn.landingPreview = function() {
     };
 
 
-    $landButton.on('click', () => {
+    $form.on('submit', () => {
       $landButton.attr({'disabled': true});
       $landButton.text('Landing in progress...');
     });


### PR DESCRIPTION
Due to some browser differences, when a button is disabled in its own click
handler, if that button results in form submission the form will not be
submitted in Safari or Chrome.

This issue is solved by moving the disabling of the button to the form
submit event handler.