### PR TITLE
queue: add initial queue of landings on home page (bug 1587138)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
       - SENTRY_DSN=
       - LOG_LEVEL=DEBUG
       - ENABLE_SEC_APPROVAL=1
+      - ENABLE_EMBEDDED_TRANSPLANT_UI=1
   py3-linter:
     build:
       context: ./

--- a/landoui/app.py
+++ b/landoui/app.py
@@ -80,6 +80,13 @@ def create_app(
     log_config_change('PHABRICATOR_URL', app.config['PHABRICATOR_URL'])
     app.config['ENABLE_SEC_APPROVAL'] = bool(os.getenv('ENABLE_SEC_APPROVAL'))
     log_config_change('ENABLE_SEC_APPROVAL', app.config['ENABLE_SEC_APPROVAL'])
+    app.config['ENABLE_EMBEDDED_TRANSPLANT_UI'] = (
+        bool(os.getenv('ENABLE_EMBEDDED_TRANSPLANT_UI'))
+    )
+    log_config_change(
+        'ENABLE_EMBEDDED_TRANSPLANT_UI',
+        app.config['ENABLE_EMBEDDED_TRANSPLANT_UI']
+    )
 
     # Set remaining configuration
     app.config['SECRET_KEY'] = secret_key

--- a/landoui/assets_src/css/pages/QueuePage.scss
+++ b/landoui/assets_src/css/pages/QueuePage.scss
@@ -1,0 +1,79 @@
+@import "../colors";
+
+.QueuePage {
+  
+}
+
+.QueuePage-options {
+  display: flex;
+  justify-content: space-between;
+  align-content: left;
+  margin: 1rem 0 1rem 0;
+
+  &Repo {
+    flex: 1;
+  }
+
+  &IsMine {
+    flex: 1;
+  }
+}
+
+
+.QueuePage-listHeaders {
+  display: flex;
+  justify-content: space-between;
+  font-size: 1.25rem;
+  font-weight: bold;
+
+  &Position {
+    flex: 1;
+  }
+
+  &Age {
+    flex: 1;
+  }
+
+  &Id {
+    flex: 2;
+  }
+
+  &Bug {
+    flex: 2;
+  }
+
+  &RequestedBy {
+    flex: 2;
+  }
+}
+
+.QueuePage-revision {
+  display: flex;
+  justify-content: space-between;
+  padding: 0.25rem 0 0.25rem 0;
+
+  &:hover {
+    background-color: #fff2c4;
+    cursor: pointer;
+  }
+
+  &Position {
+    flex: 1;
+  }
+
+  &Age {
+    flex: 1;
+  }
+
+  &Id {
+    flex: 2;
+  }
+
+  &Bug {
+    flex: 2;
+  }
+
+  &RequestedBy {
+    flex: 2;
+  }
+}

--- a/landoui/assets_src/js/components/Queue.js
+++ b/landoui/assets_src/js/components/Queue.js
@@ -1,0 +1,28 @@
+'use strict';
+
+$.fn.queue = function() {
+  return this.each(function() {
+    let $queue = $(this);
+    let $revisions = $queue.find('.QueuePage-revision');
+    
+    // Click into revision page
+    $revisions.on('click', (e) => {
+      window.location = $(e.currentTarget).data('revision-tip-url');
+    });
+
+    // Show all or just my revisions
+    $queue.find('.QueuePage-optionsIsMine a').on('click', (e) => {
+      e.preventDefault();
+      if($(e.target).data('show') == 'just-mine') {
+        $('[data-is-mine="false"]').hide();
+      } else {
+        $revisions.show();
+      }
+    });
+
+    // Repository toggle
+    $queue.find('.QueuePage-optionsRepo').on('click', (e) => {
+      // to be implemented
+    });
+  });
+};

--- a/landoui/assets_src/js/main.js
+++ b/landoui/assets_src/js/main.js
@@ -5,6 +5,7 @@ $(document).ready(function() {
   let $landingPreview = $('.StackPage-landingPreview');
   let $stack = $('.StackPage-stack');
   let $secRequestSubmitted = $('.StackPage-secRequestSubmitted');
+  let $queue = $('.QueuePage');
 
   // Initialize components
   $('.Navbar').landoNavbar();
@@ -12,4 +13,5 @@ $(document).ready(function() {
   $landingPreview.landingPreview();
   $stack.stack();
   $secRequestSubmitted.secRequestSubmitted();
+  $queue.queue();
 });

--- a/landoui/pages.py
+++ b/landoui/pages.py
@@ -28,7 +28,15 @@ pages.before_request(set_last_local_referrer)
 
 @pages.route('/')
 def home():
-    return render_template('home.html')
+    enable_transplant_ui = current_app.config.get(
+        "ENABLE_EMBEDDED_TRANSPLANT_UI"
+    )
+    if not (enable_transplant_ui and is_user_authenticated()):
+        # Return a static HTML page for users that are not logged in.
+        return render_template('home.html')
+
+    # Render the landing queue.
+    return render_template('queue/queue.html')
 
 
 @pages.route('/signin')

--- a/landoui/templates/queue/queue.html
+++ b/landoui/templates/queue/queue.html
@@ -1,0 +1,98 @@
+{% extends "partials/layout.html" %}
+{# Fake queue data till the API is ready #}
+{% 
+  set queue_data = [
+    {
+      'priority': 1,
+      'requester_email': "user@example.com",
+      'bug_ids': [123456, 123457, 123458],
+      'repo_name': 'mozilla-central',
+      'revision_order': [1001, 1002, 1003],
+      'created_at': '2019-10-08T16:55:31.208168+00:00',
+    },
+    {
+      'priority': 1,
+      'requester_email': "imadueme@example.com",
+      'bug_ids': [323457, 323458, 323459, 323460],
+      'repo_name': 'mozilla-central',
+      'revision_order': [1225, 1226, 1227],
+      'created_at': '2019-10-08T16:55:40.10194+00:00'
+    },
+    {
+      'priority': 1,
+      'requester_email': "imadueme@example.com",
+      'bug_ids': [323456],
+      'repo_name': 'mozilla-central',
+      'revision_order': [1504],
+      'created_at': '2019-10-08T16:55:50.10194+00:00'
+    },
+    {
+      'priority': 1,
+      'requester_email': "otherperson@example.com",
+      'bug_ids': [323456],
+      'repo_name': 'mozilla-central',
+      'revision_order': [1506, 1508],
+      'created_at': '2019-10-08T16:55:58.10194+00:00'
+    },
+  ]
+%}
+{% block main %}
+<main class="QueuePage container">
+  <h1>Landing Queue</h1>
+  <div class="QueuePage-options">
+    <div class="QueuePage-optionsRepo">
+      <span>Respository: </span>
+      <select>
+          <option>
+            Mozilla-Central
+          </option>
+      </select>
+    </div>
+    
+    <div class="QueuePage-optionsIsMine">
+      <span>Show:</span> &nbsp;
+      <a href="#" data-show="all">All</a> &nbsp; | &nbsp;
+      <a href="#" data-show="just-mine">Just Mine</a>
+    </div>
+  </div>
+
+  <div class="QueuePage-listHeaders">
+    <div class="QueuePage-listHeadersPosition">Position</div>
+    <div class="QueuePage-listHeadersAge">Age</div>
+    <div class="QueuePage-listHeadersId">Revision ID</div>
+    <div class="QueuePage-listHeadersBug">Bug #</div>
+    <div class="QueuePage-listHeadersRequestedBy">Requested By</div>
+  </div>
+  <div class="QueuePage-list">
+    {% for landing in queue_data %}
+    <div
+      class="QueuePage-revision"
+      data-revision-tip-url="/D{{ landing['revision_order'][0] }}/"
+      data-is-mine="{{ 'true' if landing['requester_email'] == session['userinfo']['email'] else 'false' }}"
+      data-repository="{{ landing['repo_name'] }}">
+        <div class="QueuePage-revisionPosition">
+          {{ loop.index }}
+        </div>
+        <div class="QueuePage-revisionAge">
+          {% set age = calculate_duration(landing['created_at']) %}
+          {{ "{}m".format(age['minutes']) if age['minutes'] > 0 else ""}}
+          {{ "{}s".format(age['seconds']) }}
+        </div>
+        <div class="QueuePage-revisionId">
+          {% set revisions_count = landing['revision_order']|length %}
+          D{{ landing['revision_order'][0] }}
+          {{ "(+{} more)".format(revisions_count -1) if revisions_count - 1 > 0 else ""}}
+        </div>
+        <div class="QueuePage-revisionBug">
+          {% set bugs_count = landing['bug_ids']|length %}
+          {{ landing['bug_ids'][0] if bugs_count > 0 else ""}}
+          {{ "(+{} more)".format(bugs_count -1) if bugs_count - 1 > 0 else ""}}
+        </div>
+        <div class="QueuePage-revisionRequestedBy">
+          {{ landing['requester_email'] }}
+        </div>
+    </div>
+    {% endfor %}
+  </div>
+</main>
+{% endblock %}

--- a/tests/test_template_helpers.py
+++ b/tests/test_template_helpers.py
@@ -7,7 +7,7 @@ import pytest
 
 from landoui.template_helpers import (
     avatar_url, linkify_bug_numbers, linkify_revision_urls, linkify_faq,
-    linkify_sec_bug_wiki, repo_path
+    linkify_sec_bug_wiki, repo_path, calculate_duration
 )
 
 
@@ -169,3 +169,25 @@ def test_linkify_sec_bug_wiki(app, input_text, output_text):
 )
 def test_repo_path(app, repo_url, path):
     assert path == repo_path(repo_url)
+
+
+@pytest.mark.parametrize(
+    'start,end,duration', [
+        (
+            '2019-10-08T06:42:12.000000+00:00',
+            '2019-10-08T06:58:32.000000+00:00', {
+                'minutes': 16,
+                'seconds': 20
+            }
+        ),
+        (
+            '2019-10-10T12:42:34.012340+00:00',
+            '2019-10-10T12:42:41.045670+00:00', {
+                'minutes': 0,
+                'seconds': 7
+            }
+        ),
+    ]
+)
+def test_calculate_duration(app, start, end, duration):
+    assert duration == calculate_duration(start, end)


### PR DESCRIPTION
Adds the initial queue of landings on the index page.

This queue will only show up when the ENABLE_EMBEDDED_TRANSPLANT_UI
flag is enabled and the user is logged in.
- In the future we can remove both of these requirements.

The landing queue currently fakes data from the api. Once the API
changes are ready we will update the UI to actually query real queue
data. The expected data format can be seen in `queue.html`.

Clicking on a revision will take the user to the revision page where
they will be able to cancel, prioritize, and see extra details about the
landing. These features will be implemented in a separate PR.