### PR TITLE
ui: add a security review request Q&A form (bug 1598748)

### DIFF
--- a/landoui/app.py
+++ b/landoui/app.py
@@ -190,6 +190,18 @@ def initialize_logging():
 
 @click.command()
 @click.option('--debug', envvar='DEBUG', type=bool, default=False)
+@click.option(
+    '--reload/--no-reload',
+    default=None,
+    help='Enable or disable the reloader. By default the reloader '
+    'is active if debug is enabled.'
+)
+@click.option(
+    '--debugger/--no-debugger',
+    default=None,
+    help='Enable or disable the debugger. By default the debugger '
+    'is active if debug is enabled.'
+)
 @click.option('--host', envvar='HOST', default='0.0.0.0')
 @click.option('--port', envvar='PORT', type=int, default=80)
 @click.option(
@@ -211,9 +223,9 @@ def initialize_logging():
 )
 @click.option('--lando-api-url', envvar='LANDO_API_URL', default=None)
 def run_dev_server(
-    debug, host, port, version_path, secret_key, session_cookie_name,
-    session_cookie_domain, session_cookie_secure, use_https,
-    enable_asset_pipeline, lando_api_url
+    debug, reload, debugger, host, port, version_path, secret_key,
+    session_cookie_name, session_cookie_domain, session_cookie_secure,
+    use_https, enable_asset_pipeline, lando_api_url
 ):
     """
     Run the development server which auto reloads when things change.
@@ -227,7 +239,13 @@ def run_dev_server(
     app.jinja_env.auto_reload = True
     app.config['TEMPLATES_AUTO_RELOAD'] = True
 
-    app.run(debug=debug, port=port, host=host)
+    app.run(
+        debug=debug,
+        port=port,
+        host=host,
+        use_reloader=reload,
+        use_debugger=debug
+    )
 
 
 def _lookup_service_url(lando_api_url, service_name):

--- a/landoui/app.py
+++ b/landoui/app.py
@@ -113,9 +113,11 @@ def create_app(
     from landoui.pages import pages
     from landoui.revisions import revisions
     from landoui.dockerflow import dockerflow
+    from landoui.secapproval import secapproval
     app.register_blueprint(pages)
     app.register_blueprint(revisions)
     app.register_blueprint(dockerflow)
+    app.register_blueprint(secapproval)
 
     # Register template helpers
     from landoui.template_helpers import template_helpers

--- a/landoui/assets_src/css/pages/SecApprovalPage.scss
+++ b/landoui/assets_src/css/pages/SecApprovalPage.scss
@@ -1,0 +1,87 @@
+@import "../colors";
+
+.SecApprovalPage {
+
+  & h1 {
+    font-size: 2em;
+    font-weight: bold;
+    margin-bottom: .25em;
+    margin-top: .5em;
+  }
+
+  & h2 {
+    font-size: 1.5em;
+    font-weight: bold;
+    margin-bottom: .25em;
+    margin-top: .5em;
+  }
+
+  & h3 {
+    font-size: 1.25em;
+    font-weight: bold;
+    margin-bottom: .25em;
+    margin-top: .5em;
+  }
+
+
+  &-form {
+
+    & fieldset {
+      border: none;
+    }
+
+    & label {
+      font-weight: normal;
+    }
+
+    &-fields {
+      margin-left: 1rem;
+    }
+
+    & .field {
+      margin-bottom: 2rem;
+    }
+
+    &-fields {
+      padding: 1rem;
+    }
+
+    &-secquestions {
+      background-color: #e9e9e9;
+      padding: 2rem 1rem;
+    }
+
+    &-altmessage {
+      background-color: #e9e9e9;
+      padding: 2rem 1rem;
+
+      &-preview {
+        font-family: 'Fira Mono', monospace;
+        font-size: 1em;
+        white-space: pre-wrap;
+        height: auto;
+        width: 90ch;
+        line-height: 1.25em;
+        margin: 1ch;
+        color: inherit;
+        background-color: inherit;
+        border: 1px dashed black;
+        padding: 0.5ch;
+      }
+
+      & legend {
+        font-size: 1.25em;
+        font-weight: bold;
+        margin-bottom: .25em;
+        margin-top: .5em;
+      }
+    }
+
+    &-updatedtitle, &-updatedsummary {
+      font-family: 'Fira Mono', monospace;
+      font-size: 1rem;
+      width: 90ch;
+      padding: 0.5ch;
+    }
+  }
+}

--- a/landoui/forms.py
+++ b/landoui/forms.py
@@ -5,8 +5,8 @@ import json
 from json.decoder import JSONDecodeError
 
 from flask_wtf import FlaskForm
-from wtforms import BooleanField, HiddenField, StringField, TextAreaField, \
-    ValidationError
+from wtforms import BooleanField, HiddenField, RadioField, StringField, \
+    TextAreaField, ValidationError
 from wtforms.validators import InputRequired, optional, Regexp
 
 
@@ -62,21 +62,89 @@ class TransplantRequestForm(FlaskForm):
     confirmation_token = HiddenField('confirmation_token')
 
 
-class SecApprovalRequestForm(FlaskForm):
-    new_message = TextAreaField(
-        'new_message',
-        validators=[
-            InputRequired(message='A valid commit message must be provided'),
-        ]
+class YesNoField(RadioField):
+    """
+    A simple boolean field displayed as a list of radio buttons
+    Will output a bool value (or None on unknown)
+    """
+
+    def post_validate(self, *args, **kwargs):
+        values = {'yes': True, 'no': False, 'unknown': None}
+        self.data = values.get(self.data)
+
+
+class SecureCommitMessageForm(FlaskForm):
+    """Form used to submit a new commit message for sec-approval."""
+
+    new_title = StringField(
+        'Updated commit title',
+        validators=[optional()],
     )
-    revision_id = StringField(
-        'revision_id',
+
+    new_summary = TextAreaField(
+        'Updated commit summary (may be blank)',
+        validators=[optional()],
+    )
+
+    def validate_new_summary(form, field):
+        if not form.new_title.data:
+            raise ValidationError(
+                "You must also supply a commit message title."
+            )
+
+
+class SecApprovalRequestForm(SecureCommitMessageForm):
+    """Form used to make a sec-approval request."""
+
+    difficulty_of_constructing_exploit_from_patch = TextAreaField(
+        'How easily could an exploit be constructed based on the patch?',
+        validators=[InputRequired()],
+    )
+
+    patch_makes_flaw_obvious = YesNoField(
+        'Do comments in the patch, the check-in comment, or tests included '
+        'in the patch paint a bulls-eye on the security problem?',
+        choices=[
+            ('yes', 'Yes'),
+            ('no', 'No'),
+            ('unknown', 'Unknown'),
+        ],
+        validators=[InputRequired()]
+    )
+
+    branches_affected_by_flaw = StringField(
+        'Which older supported branches are affected by this flaw?',
+        validators=[InputRequired()],
+    )
+
+    introduced_by_bug_number = StringField(
+        'If the flaw does not affect all branches, which bug introduced the '
+        'flaw?',
         validators=[
-            InputRequired(
-                message='A valid Revision monogram must be provided'
-            ),
-            Regexp("^D[0-9]+$"),
-        ]
+            optional(),
+            Regexp(r'\d+', message='A number is required'),
+        ],
+    )
+
+    author_has_backports_for_affected_branches = YesNoField(
+        'Do you have backports for the affected branches?',
+        choices=[
+            ('yes', 'Yes'),
+            ('no', 'No'),
+        ],
+        validators=[InputRequired()],
+    )
+
+    difficulty_of_backporting_fix = TextAreaField(
+        'If you do not have backports, how different, hard to create, and '
+        'risky will they be?',
+        validators=[optional()],
+    )
+
+    risk_of_patch_causing_regression = TextAreaField(
+        'How likely is this patch to cause regressions; how much testing does '
+        'it need?',
+        validators=[InputRequired()]
     )
 
 

--- a/landoui/secapproval.py
+++ b/landoui/secapproval.py
@@ -1,0 +1,111 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+"""Blueprint for handling the sec-approval workflow.
+
+See https://wiki.mozilla.org/Security/Bug_Approval_Process
+"""
+
+import logging
+
+from flask import abort, Blueprint, current_app, flash, redirect, \
+    render_template, session, url_for
+
+from landoui.app import oidc
+from landoui.forms import SecApprovalRequestForm
+from landoui.helpers import (
+    get_phabricator_api_token,
+    set_last_local_referrer,
+)
+from landoui.landoapi import LandoAPI
+
+logger = logging.getLogger(__name__)
+
+secapproval = Blueprint("secapproval", __name__, url_prefix="/sec-approval")
+secapproval.before_request(set_last_local_referrer)
+
+
+@secapproval.route("/D<int:revision_id>/", methods=("GET", "POST"))
+@oidc.oidc_auth
+def create(revision_id):
+    """Render and submit a sec-approval request for a revision."""
+    if not current_app.config.get("ENABLE_SEC_APPROVAL"):
+        abort(404)
+
+    form = SecApprovalRequestForm()
+    api_token = get_phabricator_api_token()
+
+    if not api_token:
+        flash(
+            "Lando needs your Phabricator API token to post sec-approval "
+            "requests and comments on your behalf. Please click on your "
+            "username in the navigation bar above and fill in your "
+            "Phabricator API key.", "warning"
+        )
+
+    api = LandoAPI(
+        current_app.config["LANDO_API_URL"],
+        auth0_access_token=session.get("access_token"),
+        phabricator_api_token=api_token,
+    )
+
+    rname = "D{}".format(revision_id)
+    stack = api.request("GET", "stacks/{}".format(rname))
+    revision = next(r for r in stack["revisions"] if r["id"] == rname)
+
+    if form.validate_on_submit() and api_token:
+        logger.info(
+            "sec-approval requested", extra={"revision_id": revision_id}
+        )
+
+        api.request(
+            "POST",
+            "requestSecApproval",
+            require_auth0=True,
+            json={
+                "revision_id":
+                rname,
+                "form_content":
+                render_sec_approval_request_comment(form, revision_id),
+            },
+        )
+
+        if form.new_title.data:
+            sanitized_message = "{}\n\n{}".format(
+                form.new_title.data, form.new_summary.data
+            ).strip()
+
+            api.request(
+                "POST",
+                "requestSecApprovalForCommitMessage",
+                require_auth0=True,
+                json={
+                    "revision_id": rname,
+                    "sanitized_message": sanitized_message
+                },
+            )
+
+        flash("Your request for security review was successful.")
+        return redirect(url_for('revisions.revision', revision_id=revision_id))
+
+    status = 400 if form.errors else 200
+
+    return (
+        render_template(
+            "secapproval/secapproval.html",
+            form=form,
+            revision_id=revision_id,
+            commit_message=revision["commit_message"],
+            commit_message_title=revision["title"],
+            commit_message_summary=revision["summary"],
+        ), status,
+    )
+
+
+def render_sec_approval_request_comment(
+    form: SecApprovalRequestForm, revision_id: int
+) -> str:
+    """Render a Phabricator ReMarkup comment holding the user's answers to
+    the sec-approval request form questions.
+    """
+    return render_template("secapproval/comment.html", form=form)

--- a/landoui/secapproval.py
+++ b/landoui/secapproval.py
@@ -52,8 +52,7 @@ def create(revision_id):
 
         payload = {
             "revision_id": rname,
-            "form_content":
-            render_sec_approval_request_comment(form, revision_id),
+            "form_content": render_sec_approval_request_comment(form),
         }
 
         if form.new_title.data:
@@ -86,9 +85,7 @@ def create(revision_id):
     )
 
 
-def render_sec_approval_request_comment(
-    form: SecApprovalRequestForm, revision_id: int
-) -> str:
+def render_sec_approval_request_comment(form: SecApprovalRequestForm) -> str:
     """Render a Phabricator ReMarkup comment holding the user's answers to
     the sec-approval request form questions.
     """

--- a/landoui/secapproval.py
+++ b/landoui/secapproval.py
@@ -58,32 +58,24 @@ def create(revision_id):
             "sec-approval requested", extra={"revision_id": revision_id}
         )
 
-        api.request(
-            "POST",
-            "requestSecApproval",
-            require_auth0=True,
-            json={
-                "revision_id":
-                rname,
-                "form_content":
-                render_sec_approval_request_comment(form, revision_id),
-            },
-        )
+        payload = {
+            "revision_id": rname,
+            "form_content":
+            render_sec_approval_request_comment(form, revision_id),
+        }
 
         if form.new_title.data:
             sanitized_message = "{}\n\n{}".format(
                 form.new_title.data, form.new_summary.data
             ).strip()
+            payload["sanitized_message"] = sanitized_message
 
-            api.request(
-                "POST",
-                "requestSecApprovalForCommitMessage",
-                require_auth0=True,
-                json={
-                    "revision_id": rname,
-                    "sanitized_message": sanitized_message
-                },
-            )
+        api.request(
+            "POST",
+            "requestSecApproval",
+            require_auth0=True,
+            json=payload,
+        )
 
         flash("Your request for security review was successful.")
         return redirect(url_for('revisions.revision', revision_id=revision_id))

--- a/landoui/secapproval.py
+++ b/landoui/secapproval.py
@@ -35,14 +35,6 @@ def create(revision_id):
     form = SecApprovalRequestForm()
     api_token = get_phabricator_api_token()
 
-    if not api_token:
-        flash(
-            "Lando needs your Phabricator API token to post sec-approval "
-            "requests and comments on your behalf. Please click on your "
-            "username in the navigation bar above and fill in your "
-            "Phabricator API key.", "warning"
-        )
-
     api = LandoAPI(
         current_app.config["LANDO_API_URL"],
         auth0_access_token=session.get("access_token"),

--- a/landoui/templates/secapproval/_macros.html
+++ b/landoui/templates/secapproval/_macros.html
@@ -35,6 +35,16 @@
   </div>
 {%- endmacro %}
 
+{# Render WTForms CSRF token errors as Bulma CSS form elements #}
+{% macro render_csrf_errors(form) -%}
+  {% if form.csrf_token.errors %}
+    <div class="container">
+      {{ render_errors(form.csrf_token) }}
+      <p class="help is-danger">Please refresh the page.</p>
+    </div>
+  {% endif %}
+{%- endmacro %}
+
 {# Render a WTForms field's errors as a Bulma CSS form element #}
 {% macro render_errors(field) -%}
   {% if field.errors %}

--- a/landoui/templates/secapproval/_macros.html
+++ b/landoui/templates/secapproval/_macros.html
@@ -1,0 +1,45 @@
+{# Render a WTForms TextAreaField as a Bulma CSS form element #}
+{% macro textarea(field, class="textarea") -%}
+  <div class="field">
+    {{ field.label(class="label") }}
+    <div class="control">
+      {{ field(class=class, **kwargs) }}
+    </div>
+    {{ render_errors(field) }}
+  </div>
+{%- endmacro %}
+
+{# Render a WTForms RadioField as a Bulma CSS form element #}
+{% macro radiobuttons(field) -%}
+  <div class="field">
+    <fieldset class="control">
+      {{ field.label(class="label") }}
+      {# Set the 'required' <input> attribute by hand because WTForms won't do it. #}
+      {% for radiofield in field %}
+        {{ radiofield(class="radio", required=True) }}
+        {{ radiofield.label(class="radio") }}
+      {% endfor %}
+    </fieldset>
+    {{ render_errors(field) }}
+  </div>
+{%- endmacro %}
+
+{# Render a WTForms StringField as a Bulma CSS form element #}
+{% macro input(field, class="input") %}
+  <div class="field">
+    {{ field.label(class="label") }}
+    <div class="control">
+      {{ field(class=class, **kwargs) }}
+    </div>
+    {{ render_errors(field) }}
+  </div>
+{%- endmacro %}
+
+{# Render a WTForms field's errors as a Bulma CSS form element #}
+{% macro render_errors(field) -%}
+  {% if field.errors %}
+    {% for error in field.errors %}
+      <p class="help is-danger">{{ error }}</p>
+    {% endfor %}
+  {% endif %}
+{%- endmacro %}

--- a/landoui/templates/secapproval/comment.html
+++ b/landoui/templates/secapproval/comment.html
@@ -1,0 +1,42 @@
+{# This template renders in Remarkup, not HTML, to be displayed in Phabricator #}
+{% macro yes_no(value) -%}
+{% if value == True %}
+{icon check color=green} Yes
+{% elif value == False %}
+{icon times color=red} No
+{% else %}
+{icon question color=blue} Unknown
+{% endif %}
+{%- endmacro %}
+
+{% macro render_answer(field) -%}
+{{ form[field].label.text }}
+
+{% set data = form[field].data %}
+{% if data %}
+  {{ data }}
+{% else %}
+  [blank]
+{% endif %}
+
+{%- endmacro %}
+
+===== Security Approval Request =====
+
+{{ render_answer('difficulty_of_constructing_exploit_from_patch') }}
+
+{{ form.patch_makes_flaw_obvious.label.text }}
+
+{{ yes_no(form.patch_makes_flaw_obvious.data) }}
+
+{{ render_answer('branches_affected_by_flaw') }}
+
+{{ render_answer('introduced_by_bug_number') }}
+
+{{ form.author_has_backports_for_affected_branches.label.text }}
+
+{{ yes_no(form.author_has_backports_for_affected_branches.data) }}
+
+{{ render_answer('difficulty_of_backporting_fix') }}
+
+{{ render_answer('risk_of_patch_causing_regression') }}

--- a/landoui/templates/secapproval/secapproval.html
+++ b/landoui/templates/secapproval/secapproval.html
@@ -1,6 +1,6 @@
 {% extends "partials/layout.html" %}
 
-{% from "secapproval/_macros.html" import input, textarea, radiobuttons %}
+{% from "secapproval/_macros.html" import input, textarea, radiobuttons, render_csrf_errors %}
 
 {% block main %}
   <main class="SecApprovalPage container">
@@ -10,6 +10,7 @@
 
     <form class="SecApprovalPage-form" method="post">
       {{ form.hidden_tag() }}
+      {{ render_csrf_errors(form) }}
       <section class="SecApprovalPage-form-secquestions section box">
         <h2 class="">Information for the security reviewers</h2>
 

--- a/landoui/templates/secapproval/secapproval.html
+++ b/landoui/templates/secapproval/secapproval.html
@@ -50,7 +50,7 @@
             <p>
               While comprehensive commit messages are generally encouraged, they should
               be omitted for security bugs and instead be posted to the Phabricator
-              commit summary (which will eventually become public).
+              revision summary (which will eventually become public).
             </p>
             <p>
               If your commit message is not secure you may provide an updated commit

--- a/landoui/templates/secapproval/secapproval.html
+++ b/landoui/templates/secapproval/secapproval.html
@@ -49,10 +49,8 @@
             </ul>
             <p>
               While comprehensive commit messages are generally encouraged, they should
-              be
-              omitted for security bugs and instead be posted in the bug report (which
-              will
-              eventually become public).
+              be omitted for security bugs and instead be posted to the Phabricator
+              commit summary (which will eventually become public).
             </p>
             <p>
               If your commit message is not secure you may provide an updated commit

--- a/landoui/templates/secapproval/secapproval.html
+++ b/landoui/templates/secapproval/secapproval.html
@@ -1,0 +1,85 @@
+{% extends "partials/layout.html" %}
+
+{% from "secapproval/_macros.html" import input, textarea, radiobuttons %}
+
+{% block main %}
+  <main class="SecApprovalPage container">
+    <h1>New Security Review Request for <a
+            href="{{ url_for('revisions.revision', revision_id=revision_id) }}">D{{ revision_id }}</a>
+    </h1>
+
+    <form class="SecApprovalPage-form" method="post">
+      {{ form.hidden_tag() }}
+      <section class="SecApprovalPage-form-secquestions section box">
+        <h2 class="">Information for the security reviewers</h2>
+
+        <div class="SecApprovalPage-form-fields">
+          {{ textarea(form.difficulty_of_constructing_exploit_from_patch) }}
+
+          {{ radiobuttons(form.patch_makes_flaw_obvious) }}
+
+          {{ input(form.branches_affected_by_flaw) }}
+
+          {{ input(form.introduced_by_bug_number, size=10, placeholder='Bug ID') }}
+
+          {{ radiobuttons(form.author_has_backports_for_affected_branches) }}
+
+          {{ textarea(form.difficulty_of_backporting_fix) }}
+
+          {{ textarea(form.risk_of_patch_causing_regression) }}
+        </div>
+
+      </section>
+      <section class="SecApprovalPage-form-altmessage section box">
+        <h2 class="">Is your commit message secure?</h2>
+        <div class="SecApprovalPage-form-fields">
+          <div class="content">
+            <h3>How to write a secure message:</h3>
+            <p>
+              The commit message for your patch needs to be secure so that it does not
+              leak
+              security-sensitive information into the Mozilla source repositories.
+            </p>
+            <p>If possible, your commit message should:</p>
+            <ul>
+              <li>Not mention security</li>
+              <li>Not mention security bugs</li>
+              <li>Not mention sec-approver groups or individuals</li>
+            </ul>
+            <p>
+              While comprehensive commit messages are generally encouraged, they should
+              be
+              omitted for security bugs and instead be posted in the bug report (which
+              will
+              eventually become public).
+            </p>
+            <p>
+              If your commit message is not secure you may provide an updated commit
+              message
+              below.
+            </p>
+          </div>
+
+          <h3>Your current commit message:</h3>
+          <pre class="SecApprovalPage-form-altmessage-preview">{{ commit_message|linkify_bug_numbers|linkify_revision_urls|safe }}</pre>
+
+          <fieldset>
+            <legend>(Optional) Provide an updated commit message title and summary:
+            </legend>
+
+            {{ input(form.new_title, class="SecApprovalPage-form-updatedtitle input") }}
+
+            {{ textarea(form.new_summary, class="SecApprovalPage-form-updatedsummary textarea") }}
+          </fieldset>
+        </div>
+      </section>
+
+      <section class="section">
+        <button class="button is-primary">
+          Ask for Security Review
+        </button>
+      </section>
+
+    </form>
+  </main>
+{% endblock %}

--- a/tests/test_sec_approval_workflow.py
+++ b/tests/test_sec_approval_workflow.py
@@ -7,7 +7,9 @@ from unittest.mock import patch, ANY
 
 import pytest
 
-SEC_APPROVAL_HTML_MARK = b'<div class="StackPage-landingPreview-secureRevisionWarning">'  # noqa
+SEC_APPROVAL_HTML_MARK = (
+    b'<div class="StackPage-landingPreview-secureRevisionWarning">'
+)  # noqa
 
 LANDO_API_STACK = {
     "revisions": [
@@ -37,7 +39,7 @@ LANDO_API_STACK = {
             "status": {
                 "display": "Accepted",
                 "value": "accepted",
-                "closed": False,
+                "closed": False
             },
             "id":
             "D1",
@@ -124,6 +126,10 @@ class LandoAPIDouble:
             # Mock response for the "POST /requestSecApproval" operation.
             # Pretend there were no problems.
             return {}
+        elif operation == "requestSecApprovalForCommitMessage":
+            # Mock response for the "POST /requestSecApprovalForCommitMessage"
+            # operation. Pretend there were no problems.
+            return {}
         else:
             raise RuntimeError(
                 "The API method for {} is not implemented by this stub".
@@ -165,6 +171,8 @@ def authenticated_session(client):
         # auth library to evaluate the session as fresh and authenticated.
         session["id_token_jwt"] = "foo_jwt"
         session["last_authenticated"] = time.time()
+
+    client.set_cookie("localhost", "phabricator-api-token", "api-123abc")
 
 
 @pytest.fixture
@@ -228,32 +236,73 @@ def test_sec_approval_workflow_mark_hidden_if_feature_flag_is_off(
     assert not sec_approval_revision_in_page(rv)
 
 
-def test_submit_alt_commit_message(
+def test_show_sec_approval_form(app, client, authenticated_session, apidouble):
+    rv = client.get("/sec-approval/D1/")
+    assert rv.status_code == 200
+
+
+def test_submit_sec_approval(app, client, authenticated_session, apidouble):
+    # Disable CSRF protection so we can submit forms without tokens.
+    app.config["WTF_CSRF_ENABLED"] = False
+
+    client.set_cookie("localhost", "phabricator-api-token", "api-123abc")
+
+    formdata = {
+        "difficulty_of_constructing_exploit_from_patch": "x",
+        "patch_makes_flaw_obvious": "yes",
+        "branches_affected_by_flaw": "x",
+        "author_has_backports_for_affected_branches": "yes",
+        "risk_of_patch_causing_regression": "x",
+    }
+
+    rv = client.post(
+        "/sec-approval/D1/", data=formdata, follow_redirects=False
+    )
+
+    assert rv.status_code == 302
+    apidouble.assert_called_with(
+        ANY,
+        "POST",
+        "requestSecApproval",
+        require_auth0=True,
+        json={"revision_id": "D1",
+              "form_content": ANY},
+    )
+
+
+def test_submit_alt_commit_message_with_form(
     app, client, authenticated_session, apidouble
 ):
     # Disable CSRF protection so we can submit forms without tokens.
     app.config["WTF_CSRF_ENABLED"] = False
 
-    client.set_cookie('localhost', 'phabricator-api-token', 'api-123abc')
+    client.set_cookie("localhost", "phabricator-api-token", "api-123abc")
 
     formdata = {
-        "revision_id": "D1",
-        "revision_url": "http://phabricator.test/D1",
-        "new_message": "s3cr3t",
+        "difficulty_of_constructing_exploit_from_patch": "x",
+        "patch_makes_flaw_obvious": "yes",
+        "branches_affected_by_flaw": "x",
+        "author_has_backports_for_affected_branches": "yes",
+        "risk_of_patch_causing_regression": "x",
+        "new_title": "clean title",
+        "new_summary": "clean summary",
     }
 
     rv = client.post(
-        "/request-sec-approval", data=formdata, follow_redirects=True
+        "/sec-approval/D1/", data=formdata, follow_redirects=False
     )
 
-    assert rv.status_code == 200
-    apidouble.assert_called_once_with(
+    assert rv.status_code == 302
+
+    new_message = "clean title\n\nclean summary"
+
+    apidouble.assert_called_with(
         ANY,
         "POST",
-        "requestSecApproval",
+        "requestSecApprovalForCommitMessage",
         require_auth0=True,
         json={
             "revision_id": "D1",
-            "sanitized_message": "s3cr3t",
+            "sanitized_message": new_message,
         },
     )

--- a/tests/test_sec_approval_workflow.py
+++ b/tests/test_sec_approval_workflow.py
@@ -299,10 +299,11 @@ def test_submit_alt_commit_message_with_form(
     apidouble.assert_called_with(
         ANY,
         "POST",
-        "requestSecApprovalForCommitMessage",
+        "requestSecApproval",
         require_auth0=True,
         json={
             "revision_id": "D1",
+            "form_content": ANY,
             "sanitized_message": new_message,
         },
     )


### PR DESCRIPTION
Add a new form for submitting both security review request questions and
 an updated commit message.

The form is not hooked up to any workflow at the moment and is only
accessible by entering the URL directly in the browser. It will
eventually replace the current sec-approval workflow.

Preview: 
![Screenshot_2019-12-13 Screenshot](https://user-images.githubusercontent.com/2806587/70824831-0e9fec00-1db1-11ea-9dd3-47ff944ee013.png)
