### PR TITLE
WIP [sec-approval#3] ui: use the new sec-approval forms for the sec-approval workflow (bug 1598748)

### DIFF
--- a/landoui/revisions.py
+++ b/landoui/revisions.py
@@ -117,8 +117,9 @@ def revision(revision_id):
     revision = None
     revisions = {}
     for r in stack['revisions']:
+        r['int_id'] = int(r['id'][1:])
         revisions[r['phid']] = r
-        if r['id'] == 'D{}'.format(revision_id):
+        if r['int_id'] == revision_id:
             revision = r['phid']
 
     # Build a mapping from phid to repository.

--- a/landoui/templates/stack/partials/landing-preview.html
+++ b/landoui/templates/stack/partials/landing-preview.html
@@ -43,44 +43,14 @@
         </div>
         <button class="StackPage-landingPreview-expand button"></button>
       </div>
-      {% if revision['should_use_sec_approval_workflow'] %}
-      <div class="StackPage-landingPreview-secureRevisionWarning">
-        <p>
-          <strong>Warning:</strong> This is a secure revision and should follow the
-          <a href="">Security Bug Approval Process</a>.
-        </p>
-        <p>
-          You should consider editing the commit message so that it does not leak
-          security-sensitive information into the Mozilla source repositories.
-        </p>
-        <button class="StackPage-landingPreview-editMessage button">Edit Commit Message</button>
-      </div>
+      {% if revision.should_use_sec_approval_workflow %}
+        {% include "stack/partials/sec_approval_warning.html" %}
       {% endif %}
       <div class="StackPage-landingPreview-displayMessagePanel">
         <pre class="StackPage-landingPreview-commitMessage">{{
         revision['commit_message']|escape_html|linkify_bug_numbers|linkify_revision_urls|safe
       }}</pre>
         <div class="StackPage-landingPreview-seeMore"></div>
-      </div>
-      <div class="StackPage-landingPreview-editMessagePanel">
-        <form action="/request-sec-approval" method="post">
-          {{sec_approval_form.csrf_token}}
-          <input type="hidden" name="revision_id" value="{{ revision['id'] }}" />
-          <label for="new_message">New commit message:</label>
-<textarea
-        cols="120"
-        rows="5"
-        name="new_message"
->{{ revision['title']|safe }}
-
-{{ revision['summary']|safe}}</textarea>
-          <ul class="StackPage-landingPreview-editMessagePanel-formErrors">
-          </ul>
-          <div class="StackPage-landingPreview-editMessagePanel-foot">
-            <button type="submit" class="button">Submit For Approval</button>
-            <button type="reset" class="StackPage-landingPreview-cancelMsgEditBtn button">Cancel</button>
-          </div>
-        </form>
       </div>
     </div>
   {% endfor %}

--- a/landoui/templates/stack/partials/sec_approval_warning.html
+++ b/landoui/templates/stack/partials/sec_approval_warning.html
@@ -1,0 +1,26 @@
+<div class="StackPage-landingPreview-secureRevisionWarning">
+  {% if revision.security.has_security_review %}
+    <p>
+      A security review has been requested for this revision.  <a href="{{ revision.id|revision_url }}">Check the review status</a>.
+    </p>
+    {% if revision.security.has_secure_commit_message %}
+      <p>
+        This revision has been given a secure commit message. <a href="{{ url_for("secapproval.change_commit_message", revision_id=revision["int_id"]) }}">Provide a different message</a>.
+      </p>
+    {% else %}
+      <p>
+        <a href="{{ url_for("secapproval.change_commit_message", revision_id=revision["int_id"]) }}">(Optional) Add a secure commit message.</a>
+      </p>
+    {% endif %}
+  {% else %}
+    <p>
+      <strong>Warning:</strong> This is a secure revision and should follow the
+      <a href="https://wiki.mozilla.org/Security/Bug_Approval_Process">Security Bug Approval Process</a>.
+    </p>
+    <p>
+      Please consider whether you changes require a review from the Firefox
+      Security Team.  If you aren't sure, please <strong><em>request a review</em></strong>.
+    </p>
+    <a class="button" href="{{ url_for("secapproval.create", revision_id=revision["int_id"]) }}">Request a Security Review</a>
+  {% endif %}
+</div>


### PR DESCRIPTION
Rewrite the sec-approval section of the landing-preview page so that
the new sec-approval create and update forms are used for sec-approval
requests.

Preview page after a sec-approval request has been made, but without a commit message:
https://phabricator.services.mozilla.com/M2/13/

Preview page with the option to edit a commit message:
https://phabricator.services.mozilla.com/M2/12/