### PR TITLE
landing jobs: ability to submit a cancel request from UI (bug 1503000)

### DIFF
--- a/landoui/assets_src/js/components/Timeline.js
+++ b/landoui/assets_src/js/components/Timeline.js
@@ -14,9 +14,13 @@ $('button.cancel-landing-job').on('click', function(e) {
     var landing_job_id = this.dataset.landing_job_id;
 
     button.addClass("is-loading");
-    fetch(`/landing_jobs/${landing_job_id}/cancel`, {
+    fetch(`/landing_jobs/${landing_job_id}`, {
         method: 'PUT',
-        headers: {'Accept': 'application/json'},
+        body: JSON.stringify({"status": "CANCELLED"}),
+        headers: {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json'
+        },
     }).then(response => {
         if (response.status == 200) {
             window.location.reload();
@@ -24,7 +28,10 @@ $('button.cancel-landing-job').on('click', function(e) {
             button.prop("disabled", true);
             button.removeClass("is-danger").removeClass("is-loading").addClass("is-warning");
             button.html("Could not cancel landing request");
-            // TODO: improve messaging here
+        } else {
+            button.prop("disabled", true);
+            button.removeClass("is-danger").removeClass("is-loading").addClass("is-warning");
+            button.html("An unknown error occurred");
         }
     });
 });

--- a/landoui/assets_src/js/components/Timeline.js
+++ b/landoui/assets_src/js/components/Timeline.js
@@ -8,3 +8,23 @@ $.fn.timeline = function() {
     $timeline.find('time[data-timestamp]').formatTime();
   });
 };
+
+$('button.cancel-landing-job').on('click', function(e) {
+    var button = $(this);
+    var landing_job_id = this.dataset.landing_job_id;
+
+    button.addClass("is-loading");
+    fetch(`/landing_jobs/${landing_job_id}/cancel`, {
+        method: 'PUT',
+        headers: {'Accept': 'application/json'},
+    }).then(response => {
+        if (response.status == 200) {
+            window.location.reload();
+        } else if (response.status == 400) {
+            button.prop("disabled", true);
+            button.removeClass("is-danger").removeClass("is-loading").addClass("is-warning");
+            button.html("Could not cancel landing request");
+            // TODO: improve messaging here
+        }
+    });
+});

--- a/landoui/revisions.py
+++ b/landoui/revisions.py
@@ -277,8 +277,8 @@ def sec_approval_request_handler():
     return jsonify({})
 
 
-@revisions.route("/landing_jobs/<int:landing_job_id>/cancel", methods=("PUT",))
-def cancel_landing_job(landing_job_id):
+@revisions.route("/landing_jobs/<int:landing_job_id>", methods=("PUT",))
+def update_landing_job(landing_job_id):
     if not is_user_authenticated():
         errors = make_form_error("You must be logged in to update a landing job.")
         return jsonify(errors=errors), 401
@@ -295,7 +295,7 @@ def cancel_landing_job(landing_job_id):
             "PUT",
             f"landing_jobs/{landing_job_id}",
             require_auth0=True,
-            json={"action": "CANCEL",},
+            json=request.get_json(),
         )
     except LandoAPIError as e:
         return e.response, e.response["status"]

--- a/landoui/revisions.py
+++ b/landoui/revisions.py
@@ -277,6 +277,31 @@ def sec_approval_request_handler():
     return jsonify({})
 
 
+@revisions.route("/landing_jobs/<int:landing_job_id>/cancel", methods=("PUT",))
+def cancel_landing_job(landing_job_id):
+    if not is_user_authenticated():
+        errors = make_form_error("You must be logged in to update a landing job.")
+        return jsonify(errors=errors), 401
+
+    token = get_phabricator_api_token()
+    api = LandoAPI(
+        current_app.config["LANDO_API_URL"],
+        auth0_access_token=session.get("access_token"),
+        phabricator_api_token=token,
+    )
+
+    try:
+        data = api.request(
+            "PUT",
+            f"landing_jobs/{landing_job_id}",
+            require_auth0=True,
+            json={"action": "CANCEL",},
+        )
+    except LandoAPIError as e:
+        return e.response, e.response["status"]
+    return data
+
+
 def make_form_error(message):
     """Turn a string into an error that looks like a WTForm validation error.
 

--- a/landoui/templates/stack/partials/timeline.html
+++ b/landoui/templates/stack/partials/timeline.html
@@ -1,29 +1,29 @@
 <div class="StackPage-timeline">
     {% if transplants %}
-      {%- for job in transplants|sort(attribute='updated_at', reverse=True) %}
+      {%- for transplant in transplants|sort(attribute='updated_at', reverse=True) %}
         <div class="StackPage-timeline-item">
           <div class="StackPage-timeline-itemStatus">
-            <span class="{{job|tostatusbadgeclass}}">{{job|tostatusbadgename}}</span>
+            <span class="{{transplant|tostatusbadgeclass}}">{{transplant|tostatusbadgename}}</span>
           </div>
 
           <div class="StackPage-timeline-itemDetail">
-            On <time data-timestamp="{{job['created_at']}}"></time>, by {{job['requester_email']}}.<br>
+            On <time data-timestamp="{{transplant['created_at']}}"></time>, by {{transplant['requester_email']}}.<br>
             <strong>Revisions:</strong>
-            {% for i in job['landing_path'] %}{{
+            {% for i in transplant['landing_path'] %}{{
               "" if loop.first else " ← "
             }}<a href="{{i['revision_id']|revision_url(diff_id=i['diff_id'])}}">
                 {{i['revision_id']}} diff {{i['diff_id']}}
             </a>{% endfor %}
             <br>
-            {% if job.status.lower() == 'landed' %}
-              <strong>Result:</strong> {{job.details|escape_html|linkify_transplant_details(job)|safe}}
-            {% elif job.details %}
+            {% if transplant.status.lower() == 'landed' %}
+              <strong>Result:</strong> {{transplant.details|escape_html|linkify_transplant_details(transplant)|safe}}
+            {% elif transplant.details %}
               <div class="StackPage-timeline-item-error">
-                <strong>Details:</strong> {{job.details}}
+                <strong>Details:</strong> {{transplant.details}}
               </div>
             {% endif %}
-            {% if job.status == "SUBMITTED" %}
-                <button data-landing_job_id="{{job.id}}" class="cancel-landing-job button is-small is-danger">Cancel landing request</button>
+            {% if transplant.status == "SUBMITTED" %}
+                <button data-landing_job_id="{{transplant.id}}" class="cancel-landing-job button is-small is-danger">Cancel landing request</button>
             {% endif %}
           </div>
         </div>

--- a/landoui/templates/stack/partials/timeline.html
+++ b/landoui/templates/stack/partials/timeline.html
@@ -3,27 +3,27 @@
       {%- for transplant in transplants|sort(attribute='updated_at', reverse=True) %}
         <div class="StackPage-timeline-item">
           <div class="StackPage-timeline-itemStatus">
-            <span class="{{transplant|tostatusbadgeclass}}">{{transplant|tostatusbadgename}}</span>
+            <span class="{{ transplant|tostatusbadgeclass }}">{{transplant|tostatusbadgename}}</span>
           </div>
 
           <div class="StackPage-timeline-itemDetail">
-            On <time data-timestamp="{{transplant['created_at']}}"></time>, by {{transplant['requester_email']}}.<br>
+            On <time data-timestamp="{{ transplant['created_at'] }}"></time>, by {{ transplant['requester_email'] }}.<br>
             <strong>Revisions:</strong>
             {% for i in transplant['landing_path'] %}{{
               "" if loop.first else " ← "
-            }}<a href="{{i['revision_id']|revision_url(diff_id=i['diff_id'])}}">
-                {{i['revision_id']}} diff {{i['diff_id']}}
+            }}<a href="{{ i['revision_id']|revision_url(diff_id=i['diff_id']) }}">
+                {{ i['revision_id'] }} diff {{ i['diff_id'] }}
             </a>{% endfor %}
             <br>
-            {% if transplant.status.lower() == 'landed' %}
-              <strong>Result:</strong> {{transplant.details|escape_html|linkify_transplant_details(transplant)|safe}}
-            {% elif transplant.details %}
+            {% if transplant['status'].lower() == 'landed' %}
+              <strong>Result:</strong> {{ transplant['details']|escape_html|linkify_transplant_details(transplant)|safe }}
+            {% elif transplant['details'] %}
               <div class="StackPage-timeline-item-error">
-                <strong>Details:</strong> {{transplant.details}}
+                <strong>Details:</strong> {{ transplant['details'] }}
               </div>
             {% endif %}
-            {% if transplant.status == "SUBMITTED" %}
-                <button data-landing_job_id="{{transplant.id}}" class="cancel-landing-job button is-small is-danger">Cancel landing request</button>
+            {% if transplant['status'] == "SUBMITTED" %}
+                <button data-landing_job_id="{{ transplant['id'] }}" class="cancel-landing-job button is-small is-danger">Cancel landing request</button>
             {% endif %}
           </div>
         </div>

--- a/landoui/templates/stack/partials/timeline.html
+++ b/landoui/templates/stack/partials/timeline.html
@@ -1,26 +1,29 @@
 <div class="StackPage-timeline">
     {% if transplants %}
-      {%- for status in transplants|sort(attribute='updated_at', reverse=True) %}
+      {%- for job in transplants|sort(attribute='updated_at', reverse=True) %}
         <div class="StackPage-timeline-item">
           <div class="StackPage-timeline-itemStatus">
-            <span class="{{status|tostatusbadgeclass}}">{{status|tostatusbadgename}}</span>
+            <span class="{{job|tostatusbadgeclass}}">{{job|tostatusbadgename}}</span>
           </div>
 
           <div class="StackPage-timeline-itemDetail">
-            On <time data-timestamp="{{status['created_at']}}"></time>, by {{status['requester_email']}}.<br>
+            On <time data-timestamp="{{job['created_at']}}"></time>, by {{job['requester_email']}}.<br>
             <strong>Revisions:</strong>
-            {% for i in status['landing_path'] %}{{
+            {% for i in job['landing_path'] %}{{
               "" if loop.first else " ← "
             }}<a href="{{i['revision_id']|revision_url(diff_id=i['diff_id'])}}">
                 {{i['revision_id']}} diff {{i['diff_id']}}
             </a>{% endfor %}
             <br>
-            {% if status['status'] == 'landed' %}
-              <strong>Result:</strong> {{status['details']|escape_html|linkify_transplant_details(status)|safe}}
-            {% elif status['details'] %}
+            {% if job.status.lower() == 'landed' %}
+              <strong>Result:</strong> {{job.details|escape_html|linkify_transplant_details(job)|safe}}
+            {% elif job.details %}
               <div class="StackPage-timeline-item-error">
-                <strong>Details:</strong> {{status['details']}}
+                <strong>Details:</strong> {{job.details}}
               </div>
+            {% endif %}
+            {% if job.status == "SUBMITTED" %}
+                <button data-landing_job_id="{{job.id}}" class="cancel-landing-job button is-small is-danger">Cancel landing request</button>
             {% endif %}
           </div>
         </div>


### PR DESCRIPTION
- add UI elements to allow user to cancel a landing job
- add cancel endpoint

See https://github.com/mozilla-conduit/lando-api/pull/107 for API implementation.
See https://bugzilla.mozilla.org/show_bug.cgi?id=1503000.

Example of a job being cancelled:
![cancelling_a_landing_job](https://user-images.githubusercontent.com/2043828/86487141-57a69600-bd2b-11ea-81a4-9f69a47e0068.gif)

Example of a job that can not be cancelled (already landed). Note that a future implementation will update the button to reflect the current state.
![too_late_to_cancel_job](https://user-images.githubusercontent.com/2043828/86487147-5b3a1d00-bd2b-11ea-9f82-77ea9614540f.gif)
