### PR TITLE
stacks: add support for DONTBUILD flag (bug 1642939)

### DIFF
--- a/landoui/assets_src/js/components/LandingPreview.js
+++ b/landoui/assets_src/js/components/LandingPreview.js
@@ -15,6 +15,22 @@ $.fn.landingPreview = function() {
     // Reach outside my component, because I'm a pragmatist.
     let $previewButton = $('.StackPage-preview-button');
 
+
+
+    // Form currently resides in the footer in its own component, so we
+    // need to listen to changes on flags outside of the form and update
+    // form field accordingly. TODO: make this better.
+    document.querySelectorAll('.flag-checkbox').forEach(item => {
+        item.addEventListener('change', event => {
+            let flags = [];
+            document.querySelectorAll('.flag-checkbox:checked').forEach(flag => {
+                flags.push(flag.dataset.flag);
+            });
+            $form.find("[name=flags]").val(JSON.stringify(flags));
+        });
+    });
+
+
     let calculateLandButtonState = () => {
       if($blocker.length > 0) {
         $landButton.attr({'disabled': true});

--- a/landoui/forms.py
+++ b/landoui/forms.py
@@ -62,6 +62,7 @@ class TransplantRequestForm(FlaskForm):
         ],
     )
     confirmation_token = HiddenField("confirmation_token")
+    flags = HiddenField("flags", validators=[JSONDecodable(decode_type=list)])
 
 
 class SecApprovalRequestForm(FlaskForm):

--- a/landoui/revisions.py
+++ b/landoui/revisions.py
@@ -98,6 +98,7 @@ def revision(revision_id):
                     json={
                         "landing_path": json.loads(form.landing_path.data),
                         "confirmation_token": form.confirmation_token.data,
+                        "flags": json.loads(form.flags.data),
                     },
                 )
                 # We don't actually need any of the data from the

--- a/landoui/templates/stack/partials/landing-preview.html
+++ b/landoui/templates/stack/partials/landing-preview.html
@@ -85,6 +85,23 @@
     </div>
   {% endfor %}
   </div>
+
+  {% if target_repo.commit_flags %}
+  <h3 class="StackPage-landingPreview-sectionLabel">Flags:</h3>
+  <div class="StackPage-landingPreview-section">
+      {% for flag in target_repo.commit_flags %}
+        <ul>
+            <li>
+                <label class="checkbox">
+                    <input class="flag-checkbox" data-flag="{{ flag }}" type="checkbox">
+                    {{ flag }}
+                </label>
+            </li>
+        </ul>
+      {% endfor %}
+  </div>
+  {% endif %}
+
   <h3 class="StackPage-landingPreview-sectionLabel">Warnings:</h3>
   <div class="StackPage-landingPreview-section StackPage-landingPreview-warnings">
     {% if dryrun['warnings'] %}

--- a/landoui/templates/stack/partials/landing-preview.html
+++ b/landoui/templates/stack/partials/landing-preview.html
@@ -89,6 +89,7 @@
   {% if target_repo.commit_flags %}
   <h3 class="StackPage-landingPreview-sectionLabel">Flags:</h3>
   <div class="StackPage-landingPreview-section">
+      Flags checked off below will be appended to the commit message.
       {% for flag in target_repo.commit_flags %}
         <ul>
             <li>

--- a/landoui/templates/stack/stack.html
+++ b/landoui/templates/stack/stack.html
@@ -132,6 +132,7 @@
           {{form.csrf_token}}
           {{form.landing_path}}
           {{form.confirmation_token}}
+          {{form.flags}}
           <button
               class="StackPage-landingPreview-land button"
               data-target-repo="{{ target_repo['url']|repo_path }}"


### PR DESCRIPTION
Adds a "flags" section to the preview landing dialog, showing the user available flags to append to the commit message for supported repos.