### PR TITLE
timeline: check failed paths against rejected paths (bug 1696396)

### DIFF
--- a/landoui/templates/stack/partials/timeline.html
+++ b/landoui/templates/stack/partials/timeline.html
@@ -16,12 +16,13 @@
             </a>{% endfor %}
             </p>
             {% if transplant.error_breakdown %}
+            {% set reject_paths = transplant.error_breakdown.reject_paths %}
             <p>The following files have a conflict with <a href="{{ transplant.error_breakdown.revision_id|revision_url() }}">revision D{{ transplant.error_breakdown.revision_id }}</a>:</p>
             <div class="content">
                 <ul>
-                    {% for path in transplant.error_breakdown.failed_paths %}
+                    {% for path in transplant.error_breakdown.failed_paths if path.path in reject_paths %}
                         <li><strong>{{ path.path }}</strong> @ <a href="{{ path.url }}">{{ path.changeset_id }}</a></li>
-                        {% set reject_lines = transplant.error_breakdown.reject_paths[path.path].content.split("\n") %}
+                        {% set reject_lines = reject_paths[path.path].content.split("\n") %}
                         {% if reject_lines.__len__() < 3 %}
                             <pre>{{ "\n".join(reject_lines) }}</pre>
                         {% else %}


### PR DESCRIPTION
This change is mainly for backwards compatibility with older revisions
that may have invalid paths in the error breakdown.