### PR TITLE
admin, stacks: add repo notice support (bug 1704807)

### DIFF
--- a/landoui/admin.py
+++ b/landoui/admin.py
@@ -1,0 +1,74 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+import logging
+
+from flask import (
+    Blueprint,
+    current_app,
+    jsonify,
+    request,
+    session,
+)
+
+from landoui.forms import RepoNoticeForm
+from landoui.helpers import (
+    is_user_authenticated,
+    set_last_local_referrer,
+)
+from landoui.landoapi import LandoAPI, LandoAPIError
+
+logger = logging.getLogger(__name__)
+
+repo_notices = Blueprint("repos_notices", __name__)
+repo_notices.before_request(set_last_local_referrer)
+
+
+@repo_notices.route("/repos/notices/", methods=("GET", "POST"))
+@repo_notices.route("/repos/notices/<int:notice_id>", methods=("PUT", "DELETE"))
+def manage_repo_notices(notice_id=None):
+    if not is_user_authenticated():
+        errors = {"Error": ["You must be logged in to update a landing job."]}
+        return jsonify(errors=errors), 401
+
+    api = LandoAPI(
+        current_app.config["LANDO_API_URL"],
+        auth0_access_token=session.get("access_token"),
+    )
+
+    if request.method == "GET":
+        try:
+            data = api.request("GET", "repos/notices", require_auth0=True,)
+            return jsonify(data)
+        except LandoAPIError as e:
+            return e.response, e.response["status"]
+    elif request.method == "POST":
+        try:
+            data = request.get_json()
+            form = RepoNoticeForm(data=data)
+            if not form.validate():
+                return jsonify(dict(form.errors)), 400
+
+            data = form.data.copy()
+            if data.get("start_date"):
+                data["start_date"] = data["start_date"].isoformat()
+
+            if data.get("end_date"):
+                data["end_date"] = data["end_date"].isoformat()
+
+            response = api.request(
+                "POST", "repos/notices", require_auth0=True, json=data,
+            )
+            return jsonify(response), 201
+        except LandoAPIError as e:
+            return e.response, e.response["status"]
+    elif request.method == "PUT":
+        raise NotImplementedError()
+    elif request.method == "DELETE":
+        try:
+            response = api.request(
+                "DELETE", f"repos/notices/{notice_id}", require_auth0=True
+            )
+            return jsonify(response), 200
+        except LandoAPIError as e:
+            return e.response, e.response["status"]

--- a/landoui/app.py
+++ b/landoui/app.py
@@ -120,10 +120,12 @@ def create_app(
     from landoui.pages import pages
     from landoui.revisions import revisions
     from landoui.dockerflow import dockerflow
+    from landoui.admin import repo_notices
 
     app.register_blueprint(pages)
     app.register_blueprint(revisions)
     app.register_blueprint(dockerflow)
+    app.register_blueprint(repo_notices)
 
     # Register template helpers
     from landoui.template_helpers import template_helpers

--- a/landoui/assets_src/js/components/Admin.js
+++ b/landoui/assets_src/js/components/Admin.js
@@ -1,0 +1,60 @@
+'use strict';
+
+var newRepoNoticeForm = $("#newRepoNoticeForm");
+
+newRepoNoticeForm.on("submit", function(e) {
+    e.preventDefault();
+    var form = e.target;
+    var data = new FormData(e.target);
+
+    Array.from(form.elements).forEach(element => {
+        element.classList.remove("is-danger");
+    });
+    data = Object.fromEntries(data.entries());
+    fetch("/repos/notices/", {
+        method: 'POST',
+        body: JSON.stringify(data),
+        headers: {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json'
+        },
+    }).then(response => {
+        if (response.status == 400) {
+            window.test = form;
+            return response.json();
+        } else if (response.status == 201) {
+            form.reset();
+            window.location.reload();
+        } else {
+            alert(`An unknown error has occurred with status code ${response.status}`);
+        }
+    }).then(data => {
+        for (const field in data) {
+            var element = form.elements.namedItem(field);
+            var helpText = element.parentElement.parentElement.getElementsByClassName("help")[0]
+
+            element.classList.add("is-danger");
+            helpText.classList.remove("is-info");
+            helpText.classList.add("is-danger");
+            helpText.innerHTML = data[field][0];
+        }
+    });
+});
+
+$(".archive-notice").on("click", function(e) {
+    e.preventDefault();
+    var noticeID = e.target.dataset.noticeid;
+    fetch(`/repos/notices/${noticeID}`, {
+        method: 'DELETE',
+        headers: {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json'
+        },
+    }).then(response => {
+        if (response.status == 200) {
+            window.location.reload();
+        } else {
+            alert(`An unknown error has occurred with status code ${response.status}`);
+        }
+    })
+});

--- a/landoui/forms.py
+++ b/landoui/forms.py
@@ -11,6 +11,7 @@ from wtforms import (
     StringField,
     TextAreaField,
     ValidationError,
+    DateTimeField,
 )
 from wtforms.validators import InputRequired, optional, Regexp
 
@@ -92,3 +93,15 @@ class UserSettingsForm(FlaskForm):
         ],
     )
     reset_phab_api_token = BooleanField("Delete", default="")
+
+
+class RepoNoticeForm(FlaskForm):
+    repo_identifier = StringField(
+        validators=[InputRequired(message="A repo identifier must be provided."),],
+    )
+    message = TextAreaField(
+        "message", validators=[InputRequired(message="A message must be provided."),],
+    )
+    start_date = DateTimeField(validators=(optional(),), default="")
+    end_date = DateTimeField(validators=(optional(),), default="")
+    is_warning = BooleanField()

--- a/landoui/templates/admin.html
+++ b/landoui/templates/admin.html
@@ -1,0 +1,88 @@
+{% extends "partials/layout.html" %}
+{% block page_title %}Lando Administration{% endblock %}
+{% block main %}
+<main class="container">
+<h1>Repo Notices</h1>
+<p>User repo notices to make announcements on landing pages, or to add a warning before landing. You can schedule notices ahead of time by specifying a start date and/or end date. For example, you can announce a tree closure window, a soft freeze window, etc...
+</p>
+<form id="newRepoNoticeForm">
+    {{ form.csrf_token }}
+    <table class="table">
+        <tr>
+            <th>Repo</th>
+            <th>Start Date</th>
+            <th>End Date</th>
+            <th>Message</th>
+            <th>Is Warning</th>
+            <th></th>
+        </tr>
+        <tr>
+            <td>
+                <div class="field">
+                    <div class="control">
+                        <div class="select">
+                            <select name="repo_identifier">
+                                {% for repo in repos %}
+                                    <option>{{ repo }}</option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                    </div>
+                    <p class="help is-info">Select a repository to post a new notice in.</p>
+                </div>
+            </td>
+            <td>
+                <div class="field">
+                    <div class="control">
+                        <input name="start_date" placeholder="yyyy-mm-dd hh:mm:ss" type="text" class="input">
+                    </div>
+                    <p class="help is-info">Enter a date for when this notice should be posted. The date and time should be in this format: yyyy-mm-dd hh:mm:ss.</p>
+                </div>
+            </td>
+            <td>
+                <div class="field">
+                    <div class="control">
+                        <input name="end_date" placeholder="yyyy-mm-dd hh:mm:ss" type="text" class="input">
+                    </div>
+                    <p class="help is-info">Enter a date after which this notice will be removed. The date and time should be in this format: yyyy-mm-dd hh:mm:ss.</p>
+                </div>
+            </td>
+            <td>
+                <div class="field">
+                    <div class="control">
+                        <textarea name="message" class="textarea"></textarea>
+                    </div>
+                    <p class="help is-info">Enter a message. The message will be shown on the revision page, as well as in a landing warning if this is set to be a warning.</p>
+                </div>
+            </td>
+            <td>
+                <div class="field">
+                    <div class="control">
+                        <div class="select">
+                            <select name="is_warning">
+                                <option value="false">Not a warning</option>
+                                <option value="true">A warning</option>
+                            </select>
+                        </div>
+                    </div>
+                    <p class="help is-info">If this is set to be a warning, a landing warning will be shown to the user when attempting to land.</p>
+                </div>
+            </td>
+            <td><button class="button is-primary" type="submit">Add</button></td>
+        </tr>
+        {% for notice in notices %}
+        <tr>
+            <td>{{ notice.repo_identifier }}</td>
+            <td>{{ notice.start_date }}</td>
+            <td>{{ notice.end_date }}</td>
+            <td>{{ notice.message }}</td>
+            <td>{{ notice.is_warning }}</td>
+            <td>
+                <button class="button archive-notice" type="button" data-noticeid="{{ notice.id }}">Archive</button>
+            </td>
+        </tr>
+        {% endfor %}
+    </table>
+</form>
+</main>
+{% endblock %}

--- a/landoui/templates/stack/partials/landing-preview.html
+++ b/landoui/templates/stack/partials/landing-preview.html
@@ -117,10 +117,9 @@
           <label>
             <input type="checkbox" name="warnings[]" value="1" />
             {{ warning['display']|escape_html|linkify_bug_numbers|linkify_revision_urls|linkify_faq|linkify_sec_bug_docs|safe}}
-            [{% for instance in warning['instances'] %}{{
-              ", " if not loop.first else ""
-            }}{{instance['revision_id']
-            }}{% endfor %}]
+            {% for instance in warning['instances'] %}
+            <br><strong>{{instance['revision_id']}}</strong>: {{instance['details']}}
+            {% endfor %}
           </label>
         </li>
       {% endfor %}

--- a/landoui/templates/stack/stack.html
+++ b/landoui/templates/stack/stack.html
@@ -3,6 +3,13 @@
 
 {% block main %}
 <main class="StackPage container fullhd">
+{% for repo in stack.repo_notices %}
+    {% for notice in stack.repo_notices[repo] %}
+        <div class="notification Badge--warning">
+            {{ notice.message }}
+        </div>
+    {% endfor %}
+{% endfor %}
   {% if errors %}
   <div class="StackPage-errors">
     <span>Landing Failed</span>


### PR DESCRIPTION
- add admin page to add repo notices
- add support for repo notice on stack page
- add support for landing warning on landing preview modal
- add endpoints to add and archive notices
- show error and validation feedback when submitting new notice