### PR TITLE
stacks: hide uplift request form behind Phab API token (Bug 1794606)

### DIFF
--- a/landoui/template_helpers.py
+++ b/landoui/template_helpers.py
@@ -24,6 +24,11 @@ def is_user_authenticated():
 
 
 @template_helpers.app_template_global()
+def is_api_token_available() -> bool:
+    return helpers.get_phabricator_api_token() is not None
+
+
+@template_helpers.app_template_global()
 def new_settings_form():
     return UserSettingsForm()
 

--- a/landoui/template_helpers.py
+++ b/landoui/template_helpers.py
@@ -24,7 +24,7 @@ def is_user_authenticated():
 
 
 @template_helpers.app_template_global()
-def is_api_token_available() -> bool:
+def user_has_phabricator_token() -> bool:
     return helpers.get_phabricator_api_token() is not None
 
 

--- a/landoui/templates/stack/stack.html
+++ b/landoui/templates/stack/stack.html
@@ -142,12 +142,14 @@
           </button>
           <button class="StackPage-landingPreview-close button">Cancel</button>
         </form>
-        <form class="StackPage-landingPreview-uplift" action="{{ url_for('revisions.uplift') }}" method="post">
-          {{ uplift_request_form.csrf_token }}
-          {{ uplift_request_form.landing_path }}
-          {{ uplift_request_form.repository }}
-          <button class="button">Request uplift</button>
-        </form>
+        {% if is_api_token_available() %}
+            <form class="StackPage-landingPreview-uplift" action="{{ url_for('revisions.uplift') }}" method="post">
+              {{ uplift_request_form.csrf_token }}
+              {{ uplift_request_form.landing_path }}
+              {{ uplift_request_form.repository }}
+              <button class="button">Request uplift</button>
+            </form>
+        {% endif %}
       </footer>
     </div>
   </div>

--- a/landoui/templates/stack/stack.html
+++ b/landoui/templates/stack/stack.html
@@ -142,7 +142,7 @@
           </button>
           <button class="StackPage-landingPreview-close button">Cancel</button>
         </form>
-        {% if is_api_token_available() %}
+        {% if user_has_phabricator_token() %}
             <form class="StackPage-landingPreview-uplift" action="{{ url_for('revisions.uplift') }}" method="post">
               {{ uplift_request_form.csrf_token }}
               {{ uplift_request_form.landing_path }}


### PR DESCRIPTION
Adds a global template function to check if the Phabricator
API token is available in the local host. This function simply
checks the value of `get_phabricator_api_token` is not `None`.
If the token is present, the uplift request button is added to
the landing dialog.
