### PR TITLE
uplift: do not require auth0 token to populate uplift repo list (Bug 1797168)

### DIFF
--- a/landoui/revisions.py
+++ b/landoui/revisions.py
@@ -78,7 +78,7 @@ def annotate_sec_approval_workflow_info(revisions):
 
 def get_uplift_repos(api: LandoAPI) -> list[tuple[str, str]]:
     """Return the set of uplift repositories as a list of `(name, value)` tuples."""
-    uplift_repos = api.request("GET", "uplift", require_auth0=True)
+    uplift_repos = api.request("GET", "uplift")
     return [(repo, repo) for repo in uplift_repos["repos"]]
 
 


### PR DESCRIPTION
Despite the token not being required on the API side, the UI side
has `require_auth0=True`. This results in an `AssertionError`
when trying to add the token to the request. Unmark the API call
as requiring Auth0.
