### PR TITLE
sentry: migrate from `raven` to `sentry-sdk` (Bug 1797311)

### DIFF
--- a/landoui/app.py
+++ b/landoui/app.py
@@ -81,7 +81,7 @@ def create_app(
     # Set configuration
     version_info = get_app_version(version_path)
     logger.info("application version", extra=version_info)
-    initialize_sentry(app, version_info["version"])
+    initialize_sentry(version_info["version"])
 
     set_config_param(app, "LANDO_API_URL", lando_api_url)
     set_config_param(

--- a/landoui/errorhandlers.py
+++ b/landoui/errorhandlers.py
@@ -3,9 +3,9 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 import logging
 
+import sentry_sdk
 from flask import render_template
 
-from landoui.sentry import sentry
 from landoui.landoapi import (
     LandoAPICommunicationException,
     LandoAPIError,
@@ -86,7 +86,7 @@ def unexpected_error(e):
     """Handler for all uncaught Exceptions."""
 
     logger.exception("unexpected error")
-    sentry.captureException()
+    sentry_sdk.capture_exception()
 
     return (
         render_template(
@@ -102,7 +102,7 @@ def unexpected_error(e):
 
 
 def landoapi_communication(e):
-    sentry.captureException()
+    sentry_sdk.capture_exception()
     logger.exception("Uncaught communication exception with Lando API.")
 
     return (
@@ -119,7 +119,7 @@ def landoapi_communication(e):
 
 
 def landoapi_exception(e):
-    sentry.captureException()
+    sentry_sdk.capture_exception()
     logger.exception("Uncaught communication exception with Lando API.")
 
     if e.status_code == 503:

--- a/requirements.in
+++ b/requirements.in
@@ -22,8 +22,8 @@ pyopenssl==18.0.0
 pytest-flask==0.15.1
 pytest==5.3.5
 pyyaml==5.4.1
-raven==6.10.0
 requests_mock==1.7.0
+sentry-sdk==1.10.1
 uwsgi==2.0.18
 webassets==0.12.1
 werkzeug==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,6 +40,7 @@ certifi==2018.10.15 \
     # via
     #   -r requirements.in
     #   requests
+    #   sentry-sdk
 cffi==1.14.0 \
     --hash=sha256:001bf3242a1bb04d985d63e138230802c6c8d4db3668fb545fb5005ddf5bb5ff \
     --hash=sha256:00789914be39dffba161cfc5be31b55775de5ba2235fe49aa28c148236c4e06b \
@@ -339,10 +340,6 @@ pyyaml==5.4.1 \
     --hash=sha256:fdc842473cd33f45ff6bce46aea678a54e3d21f1b61a7750ce3c498eedfe25d6 \
     --hash=sha256:fe69978f3f768926cfa37b867e3843918e012cf83f680806599ddce33c2c68b0
     # via -r requirements.in
-raven==6.10.0 \
-    --hash=sha256:3fa6de6efa2493a7c827472e984ce9b020797d0da16f1db67197bcc23c8fae54 \
-    --hash=sha256:44a13f87670836e153951af9a3c80405d36b43097db869a36e92809673692ce4
-    # via -r requirements.in
 regex==2021.11.10 \
     --hash=sha256:0416f7399e918c4b0e074a0f66e5191077ee2ca32a0f99d4c187a62beb47aa05 \
     --hash=sha256:05b7d6d7e64efe309972adab77fc2af8907bb93217ec60aa9fe12a0dad35874f \
@@ -431,6 +428,10 @@ requests-mock==1.7.0 \
     --hash=sha256:510df890afe08d36eca5bb16b4aa6308a6f85e3159ad3013bac8b9de7bd5a010 \
     --hash=sha256:88d3402dd8b3c69a9e4f9d3a73ad11b15920c6efd36bc27bf1f701cf4a8e4646
     # via -r requirements.in
+sentry-sdk==1.10.1 \
+    --hash=sha256:06c0fa9ccfdc80d7e3b5d2021978d6eb9351fa49db9b5847cf4d1f2a473414ad \
+    --hash=sha256:105faf7bd7b7fa25653404619ee261527266b14103fe1389e0ce077bd23a9691
+    # via -r requirements.in
 six==1.14.0 \
     --hash=sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a \
     --hash=sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c
@@ -452,10 +453,12 @@ typing-extensions==4.0.1 \
     # via
     #   black
     #   oic
-urllib3==1.26.5 \
-    --hash=sha256:753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c \
-    --hash=sha256:a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098
-    # via requests
+urllib3==1.26.12 \
+    --hash=sha256:3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e \
+    --hash=sha256:b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997
+    # via
+    #   requests
+    #   sentry-sdk
 uwsgi==2.0.18 \
     --hash=sha256:4972ac538800fb2d421027f49b4a1869b66048839507ccf0aa2fda792d99f583
     # via -r requirements.in


### PR DESCRIPTION
Migrates Lando-ui from `raven` to `sentry-sdk` for our
Sentry integration. Mostly copy how Lando-API configures
Sentry via `sentry_sdk.init()`, but leave parsing of some
custom environment variables the same.
