### PR TITLE
landoapi: raise `requests` exception instead of `JSONDecodeError`

### DIFF
--- a/landoui/landoapi.py
+++ b/landoui/landoapi.py
@@ -69,19 +69,16 @@ class LandoAPI:
                 },
             )
 
-            try:
-                data = response.json()
-            except JSONDecodeError as exc:
-                # Raise the error from `requests` if the status was unexpected.
-                response.raise_for_status()
-
-                # Raise the JSONDecodeError if the status was okay.
-                raise exc
         except requests.RequestException as exc:
             raise LandoAPICommunicationException(
                 "An error occurred when communicating with Lando API"
             ) from exc
+
+        try:
+            data = response.json()
         except JSONDecodeError as exc:
+            response.raise_for_status()
+
             raise LandoAPICommunicationException(
                 "Lando API response could not be decoded as JSON"
             ) from exc

--- a/landoui/landoapi.py
+++ b/landoui/landoapi.py
@@ -69,7 +69,14 @@ class LandoAPI:
                 },
             )
 
-            data = response.json()
+            try:
+                data = response.json()
+            except JSONDecodeError as exc:
+                # Raise the error from `requests` if the status was unexpected.
+                response.raise_for_status()
+
+                # Raise the JSONDecodeError if the status was okay.
+                raise exc
         except requests.RequestException as exc:
             raise LandoAPICommunicationException(
                 "An error occurred when communicating with Lando API"


### PR DESCRIPTION
Sentry is categorizing any unexpected response as a `JSONDecodeError`
because those responses are typically returning HTML webpages or empty
response bodies. Catch the JSONDecodeError early and attempt to raise
the more detailed exception from `requests` if possible.
