### PR TITLE
uplift: change `landing_path` field to `revision_id` (Bug 1801926)

### DIFF
--- a/landoui/forms.py
+++ b/landoui/forms.py
@@ -85,11 +85,11 @@ class SecApprovalRequestForm(FlaskForm):
 class UpliftRequestForm(FlaskForm):
     """Form used to request uplift of a stack."""
 
-    landing_path = HiddenField(
-        "landing_path",
+    revision_id = StringField(
+        "revision_id",
         validators=[
-            InputRequired(message="A landing path is required"),
-            LandingPath(message="Landing path must be a JSON array of path objects"),
+            InputRequired(message="A valid Revision monogram must be provided"),
+            Regexp("^D[0-9]+$"),
         ],
     )
     repository = SelectField(

--- a/landoui/revisions.py
+++ b/landoui/revisions.py
@@ -110,7 +110,7 @@ def uplift():
         else:
             try:
                 try:
-                    landing_path = json.loads(uplift_request_form.landing_path.data)
+                    revision_id = uplift_request_form.revision_id.data
                     repository = uplift_request_form.repository.data
                 except json.JSONDecodeError as exc:
                     raise LandoAPICommunicationException(
@@ -122,7 +122,7 @@ def uplift():
                     "uplift",
                     require_auth0=True,
                     json={
-                        "landing_path": landing_path,
+                        "revision_id": revision_id,
                         "repository": repository,
                     },
                 )
@@ -159,6 +159,7 @@ def revision(revision_id):
 
     # Get the list of available uplift repos and populate the form with it.
     uplift_request_form.repository.choices = get_uplift_repos(api)
+    uplift_request_form.revision_id.data = revision_id
 
     errors = []
     if form.is_submitted():
@@ -251,7 +252,6 @@ def revision(revision_id):
         ]
         landing_path_json = json.dumps(landing_path)
         form.landing_path.data = landing_path_json
-        uplift_request_form.landing_path.data = landing_path_json
 
         dryrun = api.request(
             "POST",

--- a/landoui/templates/stack/stack.html
+++ b/landoui/templates/stack/stack.html
@@ -145,7 +145,7 @@
         {% if user_has_phabricator_token() %}
             <form class="StackPage-landingPreview-uplift" action="{{ url_for('revisions.uplift') }}" method="post">
               {{ uplift_request_form.csrf_token }}
-              {{ uplift_request_form.landing_path }}
+              <input type="hidden" name="revision_id" value="{{ revision_id }}" />
               {{ uplift_request_form.repository }}
               <button class="button">Request uplift</button>
             </form>


### PR DESCRIPTION
Pass the `revision_id` from the stack page through to the
uplift endpoint instead of `landing_path`.
