### PR TITLE
meta: add license headers to all relevant files (Bug 1805674)

### DIFF
--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 FROM python:3.9-slim
 
 ENV PYTHONUNBUFFERED=1

--- a/docker/py3-linter-dockerfile
+++ b/docker/py3-linter-dockerfile
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 FROM python:3.6-alpine
 
 RUN apk add gcc linux-headers libc-dev

--- a/landoui/assets_src/assets.yml
+++ b/landoui/assets_src/assets.yml
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 # Defines how the assets should be compiled.
 # All file paths are relative to the `static` folder.
 # Order matters, based on what depends on what.

--- a/landoui/assets_src/css/colors.scss
+++ b/landoui/assets_src/css/colors.scss
@@ -1,3 +1,9 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
 // In dev, you must make a change in lando.scss for changes here to be detected.
 // This file isn't autowatched by the Flask asset pipeline.
 $orange: #ff7700;

--- a/landoui/assets_src/css/components/Badge.scss
+++ b/landoui/assets_src/css/components/Badge.scss
@@ -1,3 +1,9 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
 @import "../colors";
 
 .Badge {

--- a/landoui/assets_src/css/components/FlashMessages.scss
+++ b/landoui/assets_src/css/components/FlashMessages.scss
@@ -1,3 +1,9 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
 @import "../colors";
 
 .FlashMessages {

--- a/landoui/assets_src/css/components/Footer.scss
+++ b/landoui/assets_src/css/components/Footer.scss
@@ -1,3 +1,9 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
 .Footer {
   background-color: #eee;
 }

--- a/landoui/assets_src/css/components/Navbar.scss
+++ b/landoui/assets_src/css/components/Navbar.scss
@@ -1,3 +1,9 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
 @import "../colors";
 
 .Navbar {

--- a/landoui/assets_src/css/lando.scss
+++ b/landoui/assets_src/css/lando.scss
@@ -1,3 +1,9 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
 @import "bulma/sass/utilities/initial-variables";
 @import "colors";
 

--- a/landoui/assets_src/css/pages/QueuePage.scss
+++ b/landoui/assets_src/css/pages/QueuePage.scss
@@ -1,3 +1,9 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
 @import "../colors";
 
 .QueuePage {

--- a/landoui/assets_src/css/pages/RevisionPage.scss
+++ b/landoui/assets_src/css/pages/RevisionPage.scss
@@ -1,3 +1,9 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
 $revision-spacing: 20px;
 
 /* Page Structure */

--- a/landoui/assets_src/css/pages/StackPage.scss
+++ b/landoui/assets_src/css/pages/StackPage.scss
@@ -1,3 +1,9 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
 @import "../colors";
 
 

--- a/landoui/assets_src/js/components/FlashMessages.js
+++ b/landoui/assets_src/js/components/FlashMessages.js
@@ -1,3 +1,9 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
 'use strict';
 
 $.fn.flashMessages = function () {

--- a/landoui/assets_src/js/components/LandingPreview.js
+++ b/landoui/assets_src/js/components/LandingPreview.js
@@ -1,3 +1,9 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
 'use strict';
 
 $.fn.landingPreview = function() {

--- a/landoui/assets_src/js/components/Navbar.js
+++ b/landoui/assets_src/js/components/Navbar.js
@@ -1,3 +1,9 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
 'use strict';
 
 $.fn.landoNavbar = function() {

--- a/landoui/assets_src/js/components/Queue.js
+++ b/landoui/assets_src/js/components/Queue.js
@@ -1,3 +1,9 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
 'use strict';
 
 $.fn.queue = function() {

--- a/landoui/assets_src/js/components/RequestSubmitted.js
+++ b/landoui/assets_src/js/components/RequestSubmitted.js
@@ -1,3 +1,9 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
 'use strict';
 
 $.fn.secRequestSubmitted = function() {

--- a/landoui/assets_src/js/components/Stack.js
+++ b/landoui/assets_src/js/components/Stack.js
@@ -1,3 +1,9 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
 'use strict';
 
 $.fn.stack = function() {

--- a/landoui/assets_src/js/components/Timeline.js
+++ b/landoui/assets_src/js/components/Timeline.js
@@ -1,3 +1,9 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
 'use strict';
 
 $.fn.timeline = function() {

--- a/landoui/assets_src/js/main.js
+++ b/landoui/assets_src/js/main.js
@@ -1,3 +1,9 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
 'use strict';
 
 $(document).ready(function() {

--- a/landoui/assets_src/js/utils/formatTime.js
+++ b/landoui/assets_src/js/utils/formatTime.js
@@ -1,3 +1,9 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
 'use strict';
 
 $.fn.formatTime = function() {

--- a/landoui/support/__init__.py
+++ b/landoui/support/__init__.py
@@ -1,0 +1,3 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/landoui/templates/errorhandlers/default_error.html
+++ b/landoui/templates/errorhandlers/default_error.html
@@ -1,3 +1,9 @@
+{#
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
 {% extends "partials/layout.html" %}
 {% block page_title %}{{ title }} - Lando - Mozilla{% endblock %}
 

--- a/landoui/templates/errorhandlers/revisions_404.html
+++ b/landoui/templates/errorhandlers/revisions_404.html
@@ -1,3 +1,9 @@
+{#
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
 {% extends "partials/layout.html" %}
 {% block page_title %}Revision/Diff Not Available - Lando - Mozilla{% endblock %}
 

--- a/landoui/templates/home.html
+++ b/landoui/templates/home.html
@@ -1,3 +1,9 @@
+{#
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
 {% extends "partials/layout.html" %}
 {% block main %}
 <main class="container content">

--- a/landoui/templates/partials/footer.html
+++ b/landoui/templates/partials/footer.html
@@ -1,3 +1,9 @@
+{#
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
 <footer class="Footer footer">
   <div class="container">
     <div class="content has-text-centered">

--- a/landoui/templates/partials/layout.html
+++ b/landoui/templates/partials/layout.html
@@ -1,3 +1,9 @@
+{#
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
 <!DOCTYPE html>
 <html>
 <head>

--- a/landoui/templates/partials/navbar.html
+++ b/landoui/templates/partials/navbar.html
@@ -1,3 +1,9 @@
+{#
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
 <nav class="Navbar navbar container">
   <div class="navbar-brand">
     <a class="navbar-item" href="/">

--- a/landoui/templates/partials/notifications.html
+++ b/landoui/templates/partials/notifications.html
@@ -1,3 +1,9 @@
+{#
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
 {% with messages = get_flashed_messages(with_categories=true) %}
   {% if messages %}
     <section class="FlashMessages">

--- a/landoui/templates/queue/queue.html
+++ b/landoui/templates/queue/queue.html
@@ -1,3 +1,9 @@
+{#
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
 {% extends "partials/layout.html" %}
 {# Fake queue data till the API is ready #}
 {% 

--- a/landoui/templates/signout.html
+++ b/landoui/templates/signout.html
@@ -1,3 +1,9 @@
+{#
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
 {% extends "partials/layout.html" %}
 {% block page_title %}Signed Out - Lando - Mozilla{% endblock %}
 {% block main %}

--- a/landoui/templates/stack/partials/graph-drawing.html
+++ b/landoui/templates/stack/partials/graph-drawing.html
@@ -1,3 +1,9 @@
+{#
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
 <svg class="GraphDrawing"
   width="{{ drawing_width|graph_width }}"
   height="{{graph_height()}}"

--- a/landoui/templates/stack/partials/landing-preview.html
+++ b/landoui/templates/stack/partials/landing-preview.html
@@ -1,3 +1,9 @@
+{#
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
 {% if dryrun is none %}
   <h3 class="StackPage-landingPreview-sectionLabel">Landing is Blocked</h3>
   <div class="StackPage-landingPreview-section StackPage-landingPreview-blocker">

--- a/landoui/templates/stack/partials/revision-author.html
+++ b/landoui/templates/stack/partials/revision-author.html
@@ -1,0 +1,7 @@
+{#
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+

--- a/landoui/templates/stack/partials/revision-reviewers.html
+++ b/landoui/templates/stack/partials/revision-reviewers.html
@@ -1,3 +1,9 @@
+{#
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
 <ul class="StackPage-reviewer-list">
   {%- for reviewer in reviewers %}
     <li class="{{ reviewer|reviewer_to_status_badge_class }} StackPage-reviewer-list-badge">

--- a/landoui/templates/stack/partials/revision-status.html
+++ b/landoui/templates/stack/partials/revision-status.html
@@ -1,3 +1,9 @@
+{#
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
 {% if revision['blocked_reason'] %}
 <div class="StackPage-blockerReason">
   <div class="Badge Badge--negative">

--- a/landoui/templates/stack/partials/timeline.html
+++ b/landoui/templates/stack/partials/timeline.html
@@ -1,3 +1,9 @@
+{#
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
 <div class="StackPage-timeline">
     {% if transplants %}
     {%- for transplant in transplants|sort(attribute='updated_at', reverse=True) %}

--- a/landoui/templates/stack/stack.html
+++ b/landoui/templates/stack/stack.html
@@ -1,3 +1,9 @@
+{#
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
 {% extends "partials/layout.html" %}
 {% block page_title %}{{revision_id}} - Lando - Mozilla{% endblock %}
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.


### PR DESCRIPTION
Add license headers to all relevant files in-tree. This is
essentially everything (all Python, SASS, JS etc) except the
vendored copy of Bulma.
