### PR TITLE
docker: make Python code hot-reload in local environment (Bug 1826785)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,7 @@ services:
       context: ./
       dockerfile: ./docker/Dockerfile-dev
     volumes:
-      - ./landoui/:/app/landoui
-      - ./tests/:/app/tests
+      - ./:/app
     ports:
       - "7777:7777"
     environment:

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -23,6 +23,7 @@ WORKDIR /app
 ENV FLASK_APP=landoui.dev_app:app
 ENV FLASK_RUN_PORT=9000
 ENV FLASK_RUN_HOST=0.0.0.0
+ENV FLASK_DEBUG=1
 
 RUN pip install -e .
 


### PR DESCRIPTION
Mount the full Lando-UI source directory into `/app` in the
container to conform with how Lando-API mounts volumes. Add
`FLASK_DEBUG=1` to the environment to enable hot-reloading.
