### PR TITLE
landings: linkify `D12345` text in revision warnings (Bug 1833094)

### DIFF
--- a/landoui/template_helpers.py
+++ b/landoui/template_helpers.py
@@ -175,6 +175,14 @@ def linkify_revision_urls(text: str) -> str:
 
 
 @template_helpers.app_template_filter()
+def linkify_revision_ids(text: str) -> str:
+    """Linkify `D1234` to a proper Phabricator URL."""
+    search = r"\b(D\d+)\b"
+    replace = rf'<a href="{current_app.config["PHABRICATOR_URL"]}/\g<1>">\g<1></a>'
+    return re.sub(search, replace, str(text), flags=re.IGNORECASE)
+
+
+@template_helpers.app_template_filter()
 def linkify_transplant_details(text: str, transplant: dict) -> str:
     # The transplant result is not always guaranteed to be a commit id. It
     # can be a message saying that the landing was queued and will land later.

--- a/landoui/templates/stack/partials/landing-preview.html
+++ b/landoui/templates/stack/partials/landing-preview.html
@@ -126,7 +126,7 @@
               <label>
                 <input type="checkbox" name="warnings[]" value="1" />
                 {{ dw.message|escape_html|linkify_bug_numbers|linkify_revision_urls|linkify_faq|linkify_sec_bug_docs|safe }}
-                [{{w.revision_id}}]
+                [{{ w.revision_id | linkify_revision_ids }}]
               </label>
             </li>
             {% endfor %}
@@ -138,8 +138,7 @@
             {{ warning['display']|escape_html|linkify_bug_numbers|linkify_revision_urls|linkify_faq|linkify_sec_bug_docs|safe}}
             [{% for instance in warning['instances'] %}{{
               ", " if not loop.first else ""
-            }}{{instance['revision_id']
-            }}{% endfor %}]
+            }}{{ instance['revision_id'] | linkify_revision_ids }}{% endfor %}]
           </label>
         </li>
         {% endif %}

--- a/tests/test_template_helpers.py
+++ b/tests/test_template_helpers.py
@@ -8,6 +8,7 @@ import pytest
 from landoui.template_helpers import (
     avatar_url,
     linkify_bug_numbers,
+    linkify_revision_ids,
     linkify_revision_urls,
     linkify_faq,
     linkify_sec_bug_docs,
@@ -123,6 +124,22 @@ def test_linkify_bug_numbers(app, input_text, output_text):
 )
 def test_linkify_revision_urls(app, input_text, output_text):
     assert output_text == linkify_revision_urls(input_text)
+
+
+@pytest.mark.parametrize(
+    "input_text,output_text",
+    [
+        ("D1234", '<a href="http://phabricator.test/D1234">D1234</a>'),
+        ("blah D1234", 'blah <a href="http://phabricator.test/D1234">D1234</a>'),
+        (
+            "blah in D1234.",
+            'blah in <a href="http://phabricator.test/D1234">D1234</a>.',
+        ),
+        ("(see D1234).", '(see <a href="http://phabricator.test/D1234">D1234</a>).'),
+    ],
+)
+def test_linkify_revision_ids(app, input_text, output_text):
+    assert output_text == linkify_revision_ids(input_text)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Add a new `linkify_revision_ids` template filter which converts
`DXXX` text into a linkified Phabricator URL. Add this template
filter to the warning display when landing a revision so IDs
are clickable.
