### PR TITLE
treestatus: implement Treestatus UI (Bug 1817473)

### DIFF
--- a/landoui/app.py
+++ b/landoui/app.py
@@ -54,6 +54,7 @@ def create_app(
     use_https: bool,
     enable_asset_pipeline: bool,
     lando_api_url: str,
+    treestatus_url: str,
     debug: bool = False,
 ) -> Flask:
     """
@@ -85,6 +86,7 @@ def create_app(
     initialize_sentry(version_info["version"])
 
     set_config_param(app, "LANDO_API_URL", lando_api_url)
+    set_config_param(app, "TREESTATUS_URL", treestatus_url)
     set_config_param(
         app, "BUGZILLA_URL", _lookup_service_url(lando_api_url, "bugzilla")
     )

--- a/landoui/app.py
+++ b/landoui/app.py
@@ -121,10 +121,12 @@ def create_app(
     from landoui.pages import pages
     from landoui.revisions import revisions
     from landoui.dockerflow import dockerflow
+    from landoui.treestatus import treestatus_blueprint
 
     app.register_blueprint(pages)
     app.register_blueprint(revisions)
     app.register_blueprint(dockerflow)
+    app.register_blueprint(treestatus_blueprint)
 
     # Register template helpers
     from landoui.template_helpers import template_helpers

--- a/landoui/assets_app.py
+++ b/landoui/assets_app.py
@@ -22,5 +22,6 @@ app = create_app(
     use_https=False,
     enable_asset_pipeline=True,
     lando_api_url="http://lando-api.test",
+    treestatus_url="http://treestatus.test",
     debug=True,
 )

--- a/landoui/assets_src/css/pages/TreestatusPage.scss
+++ b/landoui/assets_src/css/pages/TreestatusPage.scss
@@ -7,10 +7,12 @@
 @import "../colors";
 
 .recent-changes-update-hidden {
+    // Hide the hidden elements in the recent changes view.
     display: none;
 }
 
 .log-update-hidden {
+    // Hide the hidden elements in the log update view.
     display: none;
 }
 

--- a/landoui/assets_src/css/pages/TreestatusPage.scss
+++ b/landoui/assets_src/css/pages/TreestatusPage.scss
@@ -1,0 +1,15 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+@import "../colors";
+
+.recent-changes-update-hidden {
+    display: none;
+}
+
+.log-update-hidden {
+    display: none;
+}

--- a/landoui/assets_src/css/pages/TreestatusPage.scss
+++ b/landoui/assets_src/css/pages/TreestatusPage.scss
@@ -20,3 +20,8 @@
     // Remove the spaces between tree boxes.
     margin-bottom: 0rem !important;
 }
+
+.tree-category-header {
+    // Add some padding category header elements.
+    padding-top: 1rem;
+}

--- a/landoui/assets_src/css/pages/TreestatusPage.scss
+++ b/landoui/assets_src/css/pages/TreestatusPage.scss
@@ -13,3 +13,8 @@
 .log-update-hidden {
     display: none;
 }
+
+.select-trees-box {
+    // Remove the spaces between tree boxes.
+    margin-bottom: 0rem !important;
+}

--- a/landoui/assets_src/js/components/Treestatus.js
+++ b/landoui/assets_src/js/components/Treestatus.js
@@ -1,0 +1,32 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+$.fn.treestatus = function() {
+    return this.each(function() {
+        // Register an on-click handler for each log update edit button.
+        $('.log-update-edit').on("click", function () {
+            // Toggle the elements from hidden/visible.
+            var closest_form = $(this).closest('.log-update-form');
+            closest_form.find('.log-update-hidden').toggle();
+            closest_form.find('.log-update-visible').toggle();
+        });
+
+        // Register an on-click handler for each recent changes edit button.
+        $('.recent-changes-edit').on("click", function () {
+            // Toggle the elements from hidden/visible.
+            var closest_form = $(this).closest('.recent-changes-form');
+            closest_form.find('.recent-changes-update-hidden').toggle();
+            closest_form.find('.recent-changes-update-visible').toggle();
+        });
+
+        // Toggle selected on all trees.
+        $('.select-all-trees').on("click", function () {
+            $('.tree-select-checkbox').prop('checked', true);
+        });
+    });
+};

--- a/landoui/assets_src/js/components/Treestatus.js
+++ b/landoui/assets_src/js/components/Treestatus.js
@@ -33,6 +33,13 @@ $.fn.treestatus = function() {
             checkboxes.trigger('change');
         });
 
+        // Toggle un-selected on all trees.
+        $('.unselect-all-trees').on("click", function () {
+            var checkboxes = $('.tree-select-checkbox');
+            checkboxes.prop('checked', false);
+            checkboxes.trigger('change');
+        });
+
         // Update the select trees list after update.
         var set_update_trees_list = function () {
             // Clear the current state of the update form tree list.

--- a/landoui/assets_src/js/components/Treestatus.js
+++ b/landoui/assets_src/js/components/Treestatus.js
@@ -12,6 +12,7 @@ $.fn.treestatus = function() {
         $('.log-update-edit').on("click", function () {
             // Toggle the elements from hidden/visible.
             var closest_form = $(this).closest('.log-update-form');
+
             closest_form.find('.log-update-hidden').toggle();
             closest_form.find('.log-update-visible').toggle();
         });
@@ -20,13 +21,48 @@ $.fn.treestatus = function() {
         $('.recent-changes-edit').on("click", function () {
             // Toggle the elements from hidden/visible.
             var closest_form = $(this).closest('.recent-changes-form');
+
             closest_form.find('.recent-changes-update-hidden').toggle();
             closest_form.find('.recent-changes-update-visible').toggle();
         });
 
         // Toggle selected on all trees.
         $('.select-all-trees').on("click", function () {
-            $('.tree-select-checkbox').prop('checked', true);
+            var checkboxes = $('.tree-select-checkbox');
+            checkboxes.prop('checked', true);
+            checkboxes.trigger('change');
+        });
+
+        // Update the select trees list after update.
+        var set_update_trees_list = function () {
+            // Clear the current state of the update form tree list.
+            var trees_list = $('.update-trees-list')
+            trees_list.empty();
+
+            // Get all the checked boxes in the select trees view.
+            $('.tree-select-checkbox:checked').each(function () {
+                var checkbox = $(this);
+
+                // Add a new `li` element for each selected tree.
+                trees_list.append(
+                    $('<li></li>').text(checkbox.val())
+                );
+            });
+        };
+
+        // Show the update trees modal when "Update trees" is clicked.
+        $('.update-trees-button').on("click", function () {
+            $('.update-trees-modal').toggle();
+        });
+
+        // Close the update trees modal when the close button is clicked.
+        $('.update-trees-modal-close').on("click", function () {
+            $('.update-trees-modal').toggle();
+        });
+
+        // Add a tree to the list of trees on the update form when checkbox set.
+        $('.tree-select-checkbox').on("change", function () {
+            set_update_trees_list();
         });
     });
 };

--- a/landoui/assets_src/js/components/Treestatus.js
+++ b/landoui/assets_src/js/components/Treestatus.js
@@ -70,6 +70,11 @@ $.fn.treestatus = function() {
         // Add a tree to the list of trees on the update form when checkbox set.
         $('.tree-select-checkbox').on("change", function () {
             set_update_trees_list();
+
+            var checked_trees = $('.tree-select-checkbox:checked');
+            // Disaable the "Update trees" button when no trees are selected.
+            var is_tree_select_disabled = checked_trees.length > 0 ? false : true;
+            $('.update-trees-button').prop('disabled', is_tree_select_disabled);
         });
     });
 };

--- a/landoui/assets_src/js/main.js
+++ b/landoui/assets_src/js/main.js
@@ -12,6 +12,7 @@ $(document).ready(function() {
   let $stack = $('.StackPage-stack');
   let $secRequestSubmitted = $('.StackPage-secRequestSubmitted');
   let $flashMessages = $('.FlashMessages');
+  let $treestatus = $('.Treestatus');
 
   // Initialize components
   $('.Navbar').landoNavbar();
@@ -20,4 +21,5 @@ $(document).ready(function() {
   $stack.stack();
   $secRequestSubmitted.secRequestSubmitted();
   $flashMessages.flashMessages();
+  $treestatus.treestatus();
 });

--- a/landoui/dev_app.py
+++ b/landoui/dev_app.py
@@ -22,6 +22,7 @@ def create_dev_app(**kwargs):
         "use_https": True,
         "enable_asset_pipeline": True,
         "lando_api_url": None,
+        "treestatus_url": None,
     }
 
     # These are parameters that should be converted to a boolean value.

--- a/landoui/forms.py
+++ b/landoui/forms.py
@@ -261,6 +261,24 @@ class TreeStatusUpdateTreesForm(FlaskForm):
         if Status(self.status.data) == Status.CLOSED and category_is_empty:
             raise ValidationError("Reason category is required to close trees.")
 
+    def to_submitted_json(self) -> dict:
+        """Convert a validated form to JSON for submission to LandoAPI."""
+        # Avoid setting tags for invalid values.
+        tags = (
+            [self.reason_category.data]
+            if ReasonCategory.is_valid_for_backend(self.reason_category.data)
+            else []
+        )
+
+        return {
+            "trees": self.trees.data,
+            "status": self.status.data,
+            "reason": self.reason.data,
+            "message_of_the_day": self.message_of_the_day.data,
+            "tags": tags,
+            "remember": self.remember.data,
+        }
+
 
 class TreeCategory(enum.Enum):
     """Categories of the various trees.

--- a/landoui/forms.py
+++ b/landoui/forms.py
@@ -177,14 +177,18 @@ class ReasonCategory(enum.Enum):
         }[self]
 
     @classmethod
-    def is_valid_reason_category(cls, value: str) -> bool:
-        """Return `True` if `value` is a valid `ReasonCategory`.
+    def is_valid_for_backend(cls, value) -> bool:
+        """Return `True` if `value` is a valid `ReasonCategory` to be submitted.
 
-        Once we are using Python 3.12+, we can switch to `value in ReasonCategory`.
+        All `ReasonCategory` members are valid except for `NO_CATEGORY` as that is
+        implied by an empty `tags` key in the backend.
         """
         try:
-            cls(value)
+            category = cls(value)
         except ValueError:
+            return False
+
+        if category == ReasonCategory.NO_CATEGORY:
             return False
 
         return True

--- a/landoui/forms.py
+++ b/landoui/forms.py
@@ -134,14 +134,14 @@ class UserSettingsForm(FlaskForm):
 class Status(enum.Enum):
     """Allowable statuses of a tree."""
 
-    OPEN = "Open"
-    CLOSED = "Closed"
-    APPROVAL_REQUIRED = "Approval required"
+    OPEN = "open"
+    CLOSED = "closed"
+    APPROVAL_REQUIRED = "approval required"
 
     @classmethod
     def to_choices(cls) -> list[tuple[str, str]]:
         """Return a list of choices for display."""
-        return [(choice.value.lower(), choice.value) for choice in list(cls)]
+        return [(choice.value, choice.value.capitalize()) for choice in list(cls)]
 
 
 class ReasonCategory(enum.Enum):
@@ -248,8 +248,8 @@ class TreeStatusUpdateTreesForm(FlaskForm):
     def validate_reason(self, field):
         """Validate that the reason field is required for non-open statuses."""
         reason_is_empty = not field.data
-        # TODO use `Status.CLOSED` here instead.
-        if self.status.data == "closed" and reason_is_empty:
+
+        if Status(self.status.data) == Status.CLOSED and reason_is_empty:
             raise ValidationError("Reason description is required to close trees.")
 
     def validate_reason_category(self, field):
@@ -257,8 +257,8 @@ class TreeStatusUpdateTreesForm(FlaskForm):
         category_is_empty = (
             not field.data or ReasonCategory(field.data) == ReasonCategory.NO_CATEGORY
         )
-        # TODO use `Status.CLOSED` here instead.
-        if self.status.data == "closed" and category_is_empty:
+
+        if Status(self.status.data) == Status.CLOSED and category_is_empty:
             raise ValidationError("Reason category is required to close trees.")
 
 

--- a/landoui/forms.py
+++ b/landoui/forms.py
@@ -238,7 +238,7 @@ class TreeStatusUpdateTreesForm(FlaskForm):
         choices=ReasonCategory.to_choices(),
     )
 
-    remember_this_change = BooleanField(
+    remember = BooleanField(
         "Remember this change",
         default=True,
     )

--- a/landoui/forms.py
+++ b/landoui/forms.py
@@ -22,7 +22,6 @@ from wtforms import (
     SubmitField,
     TextAreaField,
     ValidationError,
-    widgets,
 )
 from wtforms.validators import (
     InputRequired,

--- a/landoui/forms.py
+++ b/landoui/forms.py
@@ -230,20 +230,18 @@ class TreeStatusUpdateTreesForm(FlaskForm):
     def validate_reason(self, field):
         """Validate that the reason field is required for non-open statuses."""
         reason_is_empty = not field.data
-        if self.status.data != "open" and reason_is_empty:
-            raise ValidationError(
-                "Reason description is required for non-open status changes."
-            )
+        # TODO use `Status.CLOSED` here instead.
+        if self.status.data == "closed" and reason_is_empty:
+            raise ValidationError("Reason description is required to close trees.")
 
     def validate_reason_category(self, field):
         """Validate that the reason category field is required for non-open statuses."""
         category_is_empty = (
             not field.data or ReasonCategory(field.data) == ReasonCategory.NO_CATEGORY
         )
-        if self.status.data != "open" and category_is_empty:
-            raise ValidationError(
-                "Reason category is required for non-open status changes."
-            )
+        # TODO use `Status.CLOSED` here instead.
+        if self.status.data == "closed" and category_is_empty:
+            raise ValidationError("Reason category is required to close trees.")
 
 
 class TreeStatusNewTreeForm(FlaskForm):

--- a/landoui/forms.py
+++ b/landoui/forms.py
@@ -216,6 +216,7 @@ class TreeStatusUpdateTreesForm(FlaskForm):
     reason_category = SelectField(
         "Reason Category",
         choices=ReasonCategory.to_choices(),
+        default=ReasonCategory.NO_CATEGORY.value,
     )
 
     remember = BooleanField(
@@ -241,9 +242,12 @@ class TreeStatusUpdateTreesForm(FlaskForm):
 
     def validate_reason_category(self, field):
         """Validate that the reason category field is required for non-open statuses."""
-        category_is_empty = (
-            not field.data or ReasonCategory(field.data) == ReasonCategory.NO_CATEGORY
-        )
+        try:
+            category_is_empty = (
+                not field.data or ReasonCategory(field.data) == ReasonCategory.NO_CATEGORY
+            )
+        except ValueError:
+            raise ValidationError("Reason category is an invalid value.")
 
         if Status(self.status.data) == Status.CLOSED and category_is_empty:
             raise ValidationError("Reason category is required to close trees.")

--- a/landoui/forms.py
+++ b/landoui/forms.py
@@ -147,20 +147,34 @@ class Status(enum.Enum):
 class ReasonCategory(enum.Enum):
     """Allowable reasons for a Tree closure."""
 
-    NO_CATEGORY = "No Category"
-    JOB_BACKLOG = "Job Backlog"
-    CHECKIN_COMPILE_FAILURE = "Check-in compilation failure"
-    CHECKIN_TEST_FAILURE = "Check-in test failure"
-    PLANNED_CLOSURE = "Planned closure"
-    MERGES = "Merges"
-    WAITING_FOR_COVERAGE = "Waiting for coverage"
-    INFRASTRUCTURE_RELATED = "Infrastructure related"
-    OTHER = "Other"
+    NO_CATEGORY = ""
+    JOB_BACKLOG = "backlog"
+    CHECKIN_COMPILE_FAILURE = "checkin_compilation"
+    CHECKIN_TEST_FAILURE = "checkin_test"
+    PLANNED_CLOSURE = "planned"
+    MERGES = "merges"
+    WAITING_FOR_COVERAGE = "waiting_for_coverage"
+    INFRASTRUCTURE_RELATED = "infra"
+    OTHER = "other"
 
     @classmethod
     def to_choices(cls) -> list[tuple[str, str]]:
         """Return a list of choices for display."""
-        return [(choice.value, choice.value) for choice in list(cls)]
+        return [(choice.value, choice.to_display()) for choice in list(cls)]
+
+    def to_display(self) -> str:
+        """Return a human-readable version of the category."""
+        return {
+            ReasonCategory.NO_CATEGORY: "No Category",
+            ReasonCategory.JOB_BACKLOG: "Job Backlog",
+            ReasonCategory.CHECKIN_COMPILE_FAILURE: "Check-in compilation failure",
+            ReasonCategory.CHECKIN_TEST_FAILURE: "Check-in test failure",
+            ReasonCategory.PLANNED_CLOSURE: "Planned closure",
+            ReasonCategory.MERGES: "Merges",
+            ReasonCategory.WAITING_FOR_COVERAGE: "Waiting for coverage",
+            ReasonCategory.INFRASTRUCTURE_RELATED: "Infrastructure related",
+            ReasonCategory.OTHER: "Other",
+        }[self]
 
     @classmethod
     def is_valid_reason_category(cls, value: str) -> bool:

--- a/landoui/forms.py
+++ b/landoui/forms.py
@@ -194,24 +194,6 @@ class ReasonCategory(enum.Enum):
         return True
 
 
-class TreeStatusSelectTreesForm(FlaskForm):
-    """Form used to select trees for updating."""
-
-    trees = FieldList(
-        StringField(
-            "Trees",
-            widget=widgets.HiddenInput(),
-        ),
-    )
-
-    def validate_trees(self, field):
-        """Validate that at least 1 tree was selected."""
-        if not field.entries:
-            raise ValidationError(
-                "A selection of trees is required to update statuses."
-            )
-
-
 class TreeStatusUpdateTreesForm(FlaskForm):
     """Form used to update the state of a selection of trees."""
 
@@ -221,7 +203,6 @@ class TreeStatusUpdateTreesForm(FlaskForm):
             validators=[
                 InputRequired("A selection of trees is required to update statuses.")
             ],
-            widget=widgets.HiddenInput(),
         )
     )
 
@@ -244,6 +225,13 @@ class TreeStatusUpdateTreesForm(FlaskForm):
     )
 
     message_of_the_day = StringField("Message of the day")
+
+    def validate_trees(self, field):
+        """Validate that at least 1 tree was selected."""
+        if not field.entries:
+            raise ValidationError(
+                "A selection of trees is required to update statuses."
+            )
 
     def validate_reason(self, field):
         """Validate that the reason field is required for non-open statuses."""

--- a/landoui/forms.py
+++ b/landoui/forms.py
@@ -244,12 +244,46 @@ class TreeStatusUpdateTreesForm(FlaskForm):
             raise ValidationError("Reason category is required to close trees.")
 
 
+class TreeCategory(enum.Enum):
+    """Categories of the various trees.
+
+    Note: the definition order is in order of importance for display in the UI.
+    Note: this class also exists in Lando-UI, and should be updated in both places.
+    """
+
+    DEVELOPMENT = "development"
+    RELEASE_STABILIZATION = "release_stabilization"
+    TRY = "try"
+    COMM_REPOS = "comm_repos"
+    OTHER = "other"
+
+    @classmethod
+    def sort_trees(cls, item: dict) -> int:
+        """Key function for sorting tree `dict`s according to category order."""
+        return [choice.value for choice in list(cls)].index(item["category"])
+
+    @classmethod
+    def to_choices(cls) -> list[tuple[str, str]]:
+        """Return a list of choices for display."""
+        return [(choice.value, choice.to_display()) for choice in list(cls)]
+
+    def to_display(self) -> str:
+        """Return a human readable version of the category."""
+        return " ".join(word.capitalize() for word in self.value.split("_"))
+
+
 class TreeStatusNewTreeForm(FlaskForm):
     """Add a new tree to Treestatus."""
 
     tree = StringField(
         "Tree",
         validators=[InputRequired("A tree name is required.")],
+    )
+
+    category = SelectField(
+        "Tree category",
+        choices=TreeCategory.to_choices(),
+        default=TreeCategory.OTHER.value,
     )
 
 

--- a/landoui/helpers.py
+++ b/landoui/helpers.py
@@ -14,6 +14,10 @@ def is_user_authenticated() -> bool:
     return "id_token" in session and "access_token" in session
 
 
+def is_user_authenticated_TODO() -> bool:
+    return True
+
+
 def set_last_local_referrer():
     """
     Sets the url of the last route that the user visited on this server.

--- a/landoui/helpers.py
+++ b/landoui/helpers.py
@@ -14,10 +14,6 @@ def is_user_authenticated() -> bool:
     return "id_token" in session and "access_token" in session
 
 
-def is_user_authenticated_TODO() -> bool:
-    return True
-
-
 def set_last_local_referrer():
     """
     Sets the url of the last route that the user visited on this server.

--- a/landoui/helpers.py
+++ b/landoui/helpers.py
@@ -8,8 +8,6 @@ from typing import (
 
 from flask import request, session
 
-from landoui.forms import ReasonCategory
-
 
 def is_user_authenticated() -> bool:
     """Returns whether the user is logged in or not."""

--- a/landoui/helpers.py
+++ b/landoui/helpers.py
@@ -8,6 +8,8 @@ from typing import (
 
 from flask import request, session
 
+from landoui.forms import ReasonCategory
+
 
 def is_user_authenticated() -> bool:
     """Returns whether the user is logged in or not."""

--- a/landoui/landoapi.py
+++ b/landoui/landoapi.py
@@ -40,7 +40,7 @@ class API:
 
     @property
     def service_name(self):
-        raise NotImplemented
+        raise NotImplementedError
 
     @staticmethod
     def create_session() -> requests.Session:

--- a/landoui/template_helpers.py
+++ b/landoui/template_helpers.py
@@ -12,7 +12,11 @@ import urllib.parse
 from typing import Optional
 
 from flask import Blueprint, current_app, escape
-from landoui.forms import TreeCategory, UserSettingsForm
+from landoui.forms import (
+    ReasonCategory,
+    TreeCategory,
+    UserSettingsForm,
+)
 
 from landoui import helpers
 
@@ -144,6 +148,11 @@ def tostatusbadgename(status: dict) -> str:
         "failed": "Failed to land",
     }
     return mapping.get(status["status"].lower(), status["status"].capitalize())
+
+
+@template_helpers.app_template_filter()
+def reason_category_to_display(tree_category_str: str) -> str:
+    return ReasonCategory(tree_category_str).to_display()
 
 
 @template_helpers.app_template_filter()

--- a/landoui/template_helpers.py
+++ b/landoui/template_helpers.py
@@ -32,12 +32,6 @@ def is_user_authenticated() -> bool:
     return helpers.is_user_authenticated()
 
 
-# TODO remove this
-@template_helpers.app_template_global()
-def is_user_authenticated_TODO() -> bool:
-    return helpers.is_user_authenticated_TODO()
-
-
 @template_helpers.app_template_global()
 def user_has_phabricator_token() -> bool:
     return helpers.get_phabricator_api_token() is not None

--- a/landoui/template_helpers.py
+++ b/landoui/template_helpers.py
@@ -28,6 +28,12 @@ def is_user_authenticated() -> bool:
     return helpers.is_user_authenticated()
 
 
+# TODO remove this
+@template_helpers.app_template_global()
+def is_user_authenticated_TODO() -> bool:
+    return helpers.is_user_authenticated_TODO()
+
+
 @template_helpers.app_template_global()
 def user_has_phabricator_token() -> bool:
     return helpers.get_phabricator_api_token() is not None

--- a/landoui/template_helpers.py
+++ b/landoui/template_helpers.py
@@ -151,13 +151,20 @@ def tostatusbadgename(status: dict) -> str:
 
 
 @template_helpers.app_template_filter()
-def reason_category_to_display(tree_category_str: str) -> str:
-    return ReasonCategory(tree_category_str).to_display()
+def reason_category_to_display(reason_category_str: str) -> str:
+    try:
+        return ReasonCategory(reason_category_str).to_display()
+    except ValueError:
+        # Return the bare string, in case of older data.
+        return reason_category_str
 
 
 @template_helpers.app_template_filter()
 def tree_category_to_display(tree_category_str: str) -> str:
-    return TreeCategory(tree_category_str).to_display()
+    try:
+        return TreeCategory(tree_category_str).to_display()
+    except ValueError:
+        return tree_category_str
 
 
 @template_helpers.app_template_filter()

--- a/landoui/template_helpers.py
+++ b/landoui/template_helpers.py
@@ -12,7 +12,7 @@ import urllib.parse
 from typing import Optional
 
 from flask import Blueprint, current_app, escape
-from landoui.forms import UserSettingsForm
+from landoui.forms import TreeCategory, UserSettingsForm
 
 from landoui import helpers
 
@@ -144,6 +144,11 @@ def tostatusbadgename(status: dict) -> str:
         "failed": "Failed to land",
     }
     return mapping.get(status["status"].lower(), status["status"].capitalize())
+
+
+@template_helpers.app_template_filter()
+def tree_category_to_display(tree_category_str: str) -> str:
+    return TreeCategory(tree_category_str).to_display()
 
 
 @template_helpers.app_template_filter()

--- a/landoui/template_helpers.py
+++ b/landoui/template_helpers.py
@@ -93,6 +93,16 @@ def reviewer_to_status_badge_class(reviewer: dict) -> str:
 
 
 @template_helpers.app_template_filter()
+def treestatus_to_status_badge_class(tree_status: str) -> str:
+    """Convert Tree statuses into status badges."""
+    return {
+        "open": "Badge Badge--positive",
+        "closed": "Badge Badge--negative",
+        "approval required": "Badge Badge--warning",
+    }.get(tree_status, "Badge Badge--warning")
+
+
+@template_helpers.app_template_filter()
 def reviewer_to_action_text(reviewer: dict) -> str:
     options = {
         # status: (current_diff, for_other_diff),
@@ -324,6 +334,9 @@ def message_type_to_notification_class(flash_message_category: str) -> str:
     See https://bulma.io/documentation/elements/notification/ for the list of
     Bulma notification states.
     """
-    return {"info": "is-info", "success": "is-success", "warning": "is-warning"}.get(
-        flash_message_category, "is-info"
-    )
+    return {
+        "error": "is-danger",
+        "info": "is-info",
+        "success": "is-success",
+        "warning": "is-warning",
+    }.get(flash_message_category, "is-info")

--- a/landoui/templates/partials/navbar.html
+++ b/landoui/templates/partials/navbar.html
@@ -26,6 +26,12 @@
       <div class="navbar-item">
         <div class="field is-grouped">
           <p class="control">
+            <a class="button" href="{{ url_for("treestatus.treestatus") }}">
+              <span class="icon"><i class="fa fa-tree"></i></span>
+              <span>Treestatus</span>
+            </a>
+          </p>
+          <p class="control">
             <a class="button" href="{{ config['PHABRICATOR_URL'] }}">
               <span class="icon">
                 <i class="fa fa-cog"></i>

--- a/landoui/templates/treestatus/log.html
+++ b/landoui/templates/treestatus/log.html
@@ -50,7 +50,7 @@
                             </div>
                         </div>
                         <div class="column is-narrow">
-                            {% if is_user_authenticated() %}
+                            {% if is_user_authenticated_TODO() %}
                                 <div class="log-update-visible">
                                     <button class="button is-small is-primary log-update-edit" type="button">Edit</button>
                                 </div>

--- a/landoui/templates/treestatus/log.html
+++ b/landoui/templates/treestatus/log.html
@@ -50,7 +50,7 @@
                             </div>
                         </div>
                         <div class="column is-narrow">
-                            {% if is_user_authenticated_TODO() %}
+                            {% if is_user_authenticated() %}
                                 <div class="log-update-visible">
                                     <button class="button is-small is-primary log-update-edit" type="button">Edit</button>
                                 </div>

--- a/landoui/templates/treestatus/log.html
+++ b/landoui/templates/treestatus/log.html
@@ -34,7 +34,7 @@
                                 {% if log.reason %}
                                     <div class="log-update-visible">
                                         <p>{{ log_update_form.reason.label }}: <b>{{ log.reason }}</b></p>
-                                        <p>{{ log_update_form.reason_category.label }}: <b>{{ log_update_form.reason_category.data }}</b></p>
+                                        <p>{{ log_update_form.reason_category.label }}: <b>{{ log_update_form.reason_category.data | reason_category_to_display }}</b></p>
                                     </div>
                                 {% endif %}
                                 <div class="log-update-hidden">

--- a/landoui/templates/treestatus/log.html
+++ b/landoui/templates/treestatus/log.html
@@ -1,0 +1,69 @@
+{#
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% extends "partials/layout.html" %}
+{% block page_title %}Treestatus{% endblock %}
+
+{% block main %}
+<main class="Treestatus container fullhd">
+    {% include "treestatus/recent_changes.html" %}
+
+    <h1>Treestatus: {{ tree }}</h1>
+    <p>Current status: {{ tree }} is <span class="{{ current_log.status | treestatus_to_status_badge_class }}">{{ current_log.status }}</span></p>
+
+    <div class="block">
+        <a href="{{ url_for("treestatus.treestatus") }}"><button class="button">Show All Trees</button></a>
+    </div>
+    <div class="container">
+        {% for log_update_form, log in logs %}
+            <form action="{{ url_for("treestatus.update_log", id=log.id) }}" method="post">
+                {{ log_update_form.csrf_token }}
+
+                <div class="box log-update-form">
+                    <div class="columns">
+                        <div class="column is-2">
+                            <span class="{{ log.status | treestatus_to_status_badge_class }}">{{ log.status }}</span>
+                        </div>
+                        <div class="column is-expanded">
+                            <div class="block"><b>{{ log.when }}</b></div>
+                            <div class="block"><h2 class="subtitle">{{ log.who }}</h2></div>
+                            <div class="block">
+                                {% if log.reason %}
+                                    <div class="log-update-visible">
+                                        <p>{{ log_update_form.reason.label }}: <b>{{ log.reason }}</b></p>
+                                        <p>{{ log_update_form.reason_category.label }}: <b>{{ log_update_form.reason_category.data }}</b></p>
+                                    </div>
+                                {% endif %}
+                                <div class="log-update-hidden">
+                                    <div class="field">
+                                        <label class="label">{{ log_update_form.reason.label }}</label>
+                                        {{ log_update_form.reason(id=id_string, class="input") }}
+                                    </div>
+                                    <div class="field">
+                                        <label class="label">{{ log_update_form.reason_category.label }}</label>
+                                        {{ log_update_form.reason_category(id=id_string, class="select") }}
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="column is-narrow">
+                            {% if is_user_authenticated() %}
+                                <div class="log-update-visible">
+                                    <button class="button is-small is-primary log-update-edit" type="button">Edit</button>
+                                </div>
+                            {% endif %}
+                            <div class="log-update-hidden">
+                                <button class="button delete is-normal log-update-edit" type="button"></button>
+                                <button class="button is-small is-primary">Update</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </form>
+        {% endfor %}
+    </div>
+</main>
+{% endblock %}

--- a/landoui/templates/treestatus/new_tree.html
+++ b/landoui/templates/treestatus/new_tree.html
@@ -22,6 +22,12 @@
                 </div>
                 <p class="help">The status will be "open" by default.</p>
             </div>
+            <div class="field">
+                <label class="label">{{ treestatus_new_tree_form.category.label }}</label>
+                <div class="control is-expanded">
+                    <div class="select is-fullwidth">{{ treestatus_new_tree_form.category() }}</div>
+                </div>
+            </div>
             <button class="button is-primary">Add tree</button>
         </div>
     </form>

--- a/landoui/templates/treestatus/new_tree.html
+++ b/landoui/templates/treestatus/new_tree.html
@@ -1,0 +1,29 @@
+{#
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% extends "partials/layout.html" %}
+{% block page_title %}Treestatus{% endblock %}
+
+{% block main %}
+<main class="Treestatus container fullhd">
+    {% include "treestatus/recent_changes.html" %}
+
+    <h1>Treestatus: New tree</h1>
+    <form action="{{ url_for("treestatus.new_tree") }}" method="post">
+        {{ treestatus_new_tree_form.csrf_token }}
+        <div class="box">
+            <div class="field">
+                <label class="label">{{ treestatus_new_tree_form.tree.label }}</label>
+                <div class="control is-expanded">
+                    {{ treestatus_new_tree_form.tree(class="input", placeholder="New tree name") }}
+                </div>
+                <p class="help">The status will be "open" by default.</p>
+            </div>
+            <button class="button is-primary">Add tree</button>
+        </div>
+    </form>
+</main>
+{% endblock %}

--- a/landoui/templates/treestatus/recent_changes.html
+++ b/landoui/templates/treestatus/recent_changes.html
@@ -5,7 +5,7 @@
 #}
 
 {# Only render the recent changes header if there are any changes available. #}
-{% if recent_changes_stack and is_user_authenticated() %}
+{% if recent_changes_stack and is_user_authenticated_TODO() %}
 <h1>Recent changes</h1>
 <div class="container">
     {% for status_change_form, status_change_data in recent_changes_stack %}

--- a/landoui/templates/treestatus/recent_changes.html
+++ b/landoui/templates/treestatus/recent_changes.html
@@ -1,0 +1,65 @@
+{#
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{# Only render the recent changes header if there are any changes available. #}
+{% if recent_changes_stack and is_user_authenticated() %}
+<h1>Recent changes</h1>
+<div class="container">
+    {% for status_change_form, status_change_data in recent_changes_stack %}
+    <div class="box">
+        <form class="recent-changes-form" action="{{ url_for("treestatus.update_change", id=status_change_data.id) }}" method="post">
+            {{ status_change_form.csrf_token }}
+
+            <div class="columns">
+                <div class="column">
+                    <p>At {{ status_change_data.when }}, <b>{{ status_change_data.who }}</b> changed trees:</p>
+                    <div class="block content">
+                        <ul>
+                            {% for tree in status_change_data.trees %}
+                            <li><b>{{ tree.tree }}</b>
+                                 from <span class="{{ tree.last_state.status | treestatus_to_status_badge_class }}">
+                                    {{ tree.last_state.status }}
+                                </span>
+                                 to <span class="{{ tree.last_state.current_status | treestatus_to_status_badge_class }}">
+                                    {{ tree.last_state.current_status }}
+                                </span>
+                            </li>
+                            {% endfor %}
+                        </ul>
+                    </div>
+                    <div class="recent-changes-update-visible">
+                        <p>{{ status_change_form.reason.label }}: <b>{{ status_change_form.reason.data }}</b></p>
+                        <p>{{ status_change_form.reason_category.label }}: <b>{{ status_change_form.reason_category.data }}</b></p>
+                    </div>
+                    <div class="recent-changes-update-hidden">
+                        <div class="field">
+                            <label class="label">{{ status_change_form.reason.label }}</label>
+                            <div class="control">{{ status_change_form.reason }}</div>
+                        </div>
+                        <div class="field">
+                            <label class="label">{{ status_change_form.reason_category.label }}</label>
+                            <div class="control">{{ status_change_form.reason_category }}</div>
+                        </div>
+                    </div>
+                </div>
+                <div class="column is-narrow">
+                    <div class="recent-changes-update-visible">
+                        {{ status_change_form.restore(class_="button is-success is-small") }}
+                        <button class="button is-info is-small recent-changes-edit" type="button">Edit</button>
+                        {{ status_change_form.discard(class_="button is-danger is-small") }}
+                    </div>
+                    <div class="recent-changes-update-hidden">
+                        <button class="button delete is-normal recent-changes-edit" type="button"></button>
+                        {{ status_change_form.update(class_="button is-info is-small") }}
+                    </div>
+                </div>
+            </div>
+        </form>
+    </div>
+    {% endfor %}
+</div>
+</br>
+{% endif %}

--- a/landoui/templates/treestatus/recent_changes.html
+++ b/landoui/templates/treestatus/recent_changes.html
@@ -5,7 +5,7 @@
 #}
 
 {# Only render the recent changes header if there are any changes available. #}
-{% if recent_changes_stack and is_user_authenticated_TODO() %}
+{% if recent_changes_stack and is_user_authenticated() %}
 <h1>Recent changes</h1>
 <div class="container">
     {% for status_change_form, status_change_data in recent_changes_stack %}

--- a/landoui/templates/treestatus/recent_changes.html
+++ b/landoui/templates/treestatus/recent_changes.html
@@ -32,7 +32,7 @@
                     </div>
                     <div class="recent-changes-update-visible">
                         <p>{{ status_change_form.reason.label }}: <b>{{ status_change_form.reason.data }}</b></p>
-                        <p>{{ status_change_form.reason_category.label }}: <b>{{ status_change_form.reason_category.data }}</b></p>
+                        <p>{{ status_change_form.reason_category.label }}: <b>{{ status_change_form.reason_category.data | reason_category_to_display }}</b></p>
                     </div>
                     <div class="recent-changes-update-hidden">
                         <div class="field">

--- a/landoui/templates/treestatus/trees.html
+++ b/landoui/templates/treestatus/trees.html
@@ -22,7 +22,7 @@
     <form action="{{ url_for("treestatus.update_treestatus_form") }}" method="post">
         {{ treestatus_select_trees_form.csrf_token }}
 
-        {% if is_user_authenticated_TODO() %}
+        {% if is_user_authenticated() %}
         <div class="block">
             <a href="{{ url_for("treestatus.new_tree") }}">
                 <button class="button" title="New Tree" type="button">New Tree</button>
@@ -46,7 +46,7 @@
 
             <div class="select-trees-box box">
                 <div class="columns">
-                    {% if is_user_authenticated_TODO() %}
+                    {% if is_user_authenticated() %}
                         <div class="column is-1">
                             <input class="tree-select-checkbox" type="checkbox" name="{{ tree_option.id }}" value="{{ tree_option.data }}">
                         </div>

--- a/landoui/templates/treestatus/trees.html
+++ b/landoui/templates/treestatus/trees.html
@@ -28,6 +28,7 @@
                 <button class="button" title="New Tree" type="button">New Tree</button>
             </a>
             <button class="button select-all-trees" type="button">Select all trees</button>
+            <button class="button unselect-all-trees" type="button">Unselect all trees</button>
             <button class="button is-primary update-trees-button" title="Update Tree" type="button">Update trees</button>
         </div>
         {% endif %}

--- a/landoui/templates/treestatus/trees.html
+++ b/landoui/templates/treestatus/trees.html
@@ -22,7 +22,7 @@
     <form action="{{ url_for("treestatus.update_treestatus_form") }}" method="post">
         {{ treestatus_select_trees_form.csrf_token }}
 
-        {% if is_user_authenticated() %}
+        {% if is_user_authenticated_TODO() %}
         <div class="block">
             <a href="{{ url_for("treestatus.new_tree") }}">
                 <button class="button" title="New Tree" type="button">New Tree</button>
@@ -36,7 +36,7 @@
             {% set tree = trees[tree_option.data] %}
                 <div class="box">
                     <div class="columns">
-                        {% if is_user_authenticated() %}
+                        {% if is_user_authenticated_TODO() %}
                             <div class="column is-1">
                                 <input class="tree-select-checkbox" type="checkbox" name="{{ tree_option.id }}" value="{{ tree_option.data }}">
                             </div>

--- a/landoui/templates/treestatus/trees.html
+++ b/landoui/templates/treestatus/trees.html
@@ -41,7 +41,7 @@
             {# Check if the category has changed and display a header for new category. #}
             {% if tree.category != ns.current_category %}
                 {% set ns.current_category = tree.category %}
-                <h1>{{ ns.current_category | tree_category_to_display }}</h1>
+                <h4 class="subtitle is-4 tree-category-header">{{ ns.current_category | tree_category_to_display }}</h1>
             {% endif %}
 
             <div class="select-trees-box box">

--- a/landoui/templates/treestatus/trees.html
+++ b/landoui/templates/treestatus/trees.html
@@ -31,37 +31,35 @@
             <button class="button is-primary" title="Update Tree">Update trees</button>
         </div>
         {% endif %}
-        <div class="block">
-            {% for tree_option in treestatus_select_trees_form.trees %}
-            {% set tree = trees[tree_option.data] %}
-                <div class="box">
-                    <div class="columns">
-                        {% if is_user_authenticated_TODO() %}
-                            <div class="column is-1">
-                                <input class="tree-select-checkbox" type="checkbox" name="{{ tree_option.id }}" value="{{ tree_option.data }}">
-                            </div>
+        {% for tree_option in treestatus_select_trees_form.trees %}
+        {% set tree = trees[tree_option.data] %}
+            <div class="box">
+                <div class="columns">
+                    {% if is_user_authenticated_TODO() %}
+                        <div class="column is-1">
+                            <input class="tree-select-checkbox" type="checkbox" name="{{ tree_option.id }}" value="{{ tree_option.data }}">
+                        </div>
+                    {% endif %}
+                    <div class="column is-2">
+                        <span class="{{ tree.status | treestatus_to_status_badge_class }}">{{ tree.status }}</span>
+                    </div>
+                    <div class="column">
+                        <a href="{{ tree_option.data }}"><h2 class="subtitle is-4">{{ tree_option.data }}</h2></a>
+                    </div>
+                    <div class="column">
+                        {% if tree.reason %}
+                            <p>Reason: <b>{{ tree.reason }}</b></p>
+                            <p>Reason category: <b>{{ tree.tags[0] }}</b></p>
                         {% endif %}
-                        <div class="column is-2">
-                            <span class="{{ tree.status | treestatus_to_status_badge_class }}">{{ tree.status }}</span>
-                        </div>
-                        <div class="column">
-                            <a href="{{ tree_option.data }}"><h2 class="subtitle is-4">{{ tree_option.data }}</h2></a>
-                        </div>
-                        <div class="column">
-                            {% if tree.reason %}
-                                <p>Reason: <b>{{ tree.reason }}</b></p>
-                                <p>Reason category: <b>{{ tree.tags[0] }}</b></p>
-                            {% endif %}
-                        </div>
-                        <div class="column">
-                            {% if tree.message_of_the_day %}
-                                {{ tree.message_of_the_day }}
-                            {% endif %}
-                        </div>
+                    </div>
+                    <div class="column">
+                        {% if tree.message_of_the_day %}
+                            {{ tree.message_of_the_day }}
+                        {% endif %}
                     </div>
                 </div>
-            {% endfor %}
-        </div>
+            </div>
+        {% endfor %}
     </form>
 </main>
 {% endblock %}

--- a/landoui/templates/treestatus/trees.html
+++ b/landoui/templates/treestatus/trees.html
@@ -1,0 +1,67 @@
+{#
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% extends "partials/layout.html" %}
+{% block page_title %}Treestatus{% endblock %}
+
+{% block main %}
+<main class="Treestatus container fullhd">
+    <h1>Treestatus</h1>
+    <p>Current status of Mozilla's version-control repositories.</p>
+
+    {% include "treestatus/recent_changes.html" %}
+
+    <h1>Trees</h1>
+    {#
+        The main Treestatus page is a table that presents the trees.
+        Trees can be selected here for updating, or for deletion.
+    #}
+    <form action="{{ url_for("treestatus.update_treestatus_form") }}" method="post">
+        {{ treestatus_select_trees_form.csrf_token }}
+
+        {% if is_user_authenticated() %}
+        <div class="block">
+            <a href="{{ url_for("treestatus.new_tree") }}">
+                <button class="button" title="New Tree" type="button">New Tree</button>
+            </a>
+            <button class="button select-all-trees" type="button">Select all trees</button>
+            <button class="button is-primary" title="Update Tree">Update trees</button>
+        </div>
+        {% endif %}
+        <div class="block">
+            {% for tree_option in treestatus_select_trees_form.trees %}
+            {% set tree = trees[tree_option.data] %}
+                <div class="box">
+                    <div class="columns">
+                        {% if is_user_authenticated() %}
+                            <div class="column is-1">
+                                <input class="tree-select-checkbox" type="checkbox" name="{{ tree_option.id }}" value="{{ tree_option.data }}">
+                            </div>
+                        {% endif %}
+                        <div class="column is-2">
+                            <span class="{{ tree.status | treestatus_to_status_badge_class }}">{{ tree.status }}</span>
+                        </div>
+                        <div class="column">
+                            <a href="{{ tree_option.data }}"><h2 class="subtitle is-4">{{ tree_option.data }}</h2></a>
+                        </div>
+                        <div class="column">
+                            {% if tree.reason %}
+                                <p>Reason: <b>{{ tree.reason }}</b></p>
+                                <p>Reason category: <b>{{ tree.tags[0] }}</b></p>
+                            {% endif %}
+                        </div>
+                        <div class="column">
+                            {% if tree.message_of_the_day %}
+                                {{ tree.message_of_the_day }}
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
+            {% endfor %}
+        </div>
+    </form>
+</main>
+{% endblock %}

--- a/landoui/templates/treestatus/trees.html
+++ b/landoui/templates/treestatus/trees.html
@@ -29,7 +29,7 @@
             </a>
             <button class="button select-all-trees" type="button">Select all trees</button>
             <button class="button unselect-all-trees" type="button">Unselect all trees</button>
-            <button class="button is-primary update-trees-button" title="Update Tree" type="button">Update trees</button>
+            <button class="button is-primary update-trees-button" title="Update Tree" type="button" disabled="disabled">Update trees</button>
         </div>
         {% endif %}
 

--- a/landoui/templates/treestatus/trees.html
+++ b/landoui/templates/treestatus/trees.html
@@ -31,8 +31,19 @@
             <button class="button is-primary" title="Update Tree">Update trees</button>
         </div>
         {% endif %}
+
+        {# Create a namespace to track the current category across the loop iterations. #}
+        {% set ns = namespace(current_category="") %}
+
         {% for tree_option in treestatus_select_trees_form.trees %}
-        {% set tree = trees[tree_option.data] %}
+            {% set tree = trees[tree_option.data] %}
+
+            {# Check if the category has changed and display a header for new category. #}
+            {% if tree.category != ns.current_category %}
+                {% set ns.current_category = tree.category %}
+                <h1>{{ ns.current_category | tree_category_to_display }}</h1>
+            {% endif %}
+
             <div class="select-trees-box box">
                 <div class="columns">
                     {% if is_user_authenticated_TODO() %}

--- a/landoui/templates/treestatus/trees.html
+++ b/landoui/templates/treestatus/trees.html
@@ -19,8 +19,8 @@
         The main Treestatus page is a table that presents the trees.
         Trees can be selected here for updating, or for deletion.
     #}
-    <form action="{{ url_for("treestatus.update_treestatus_form") }}" method="post">
-        {{ treestatus_select_trees_form.csrf_token }}
+    <form method="post">
+        {{ treestatus_update_trees_form.csrf_token }}
 
         {% if is_user_authenticated() %}
         <div class="block">
@@ -28,14 +28,14 @@
                 <button class="button" title="New Tree" type="button">New Tree</button>
             </a>
             <button class="button select-all-trees" type="button">Select all trees</button>
-            <button class="button is-primary" title="Update Tree">Update trees</button>
+            <button class="button is-primary update-trees-button" title="Update Tree" type="button">Update trees</button>
         </div>
         {% endif %}
 
         {# Create a namespace to track the current category across the loop iterations. #}
         {% set ns = namespace(current_category="") %}
 
-        {% for tree_option in treestatus_select_trees_form.trees %}
+        {% for tree_option in treestatus_update_trees_form.trees %}
             {% set tree = trees[tree_option.data] %}
 
             {# Check if the category has changed and display a header for new category. #}
@@ -71,6 +71,8 @@
                 </div>
             </div>
         {% endfor %}
+
+        {% include "treestatus/update_trees.html" %}
     </form>
 </main>
 {% endblock %}

--- a/landoui/templates/treestatus/trees.html
+++ b/landoui/templates/treestatus/trees.html
@@ -33,7 +33,7 @@
         {% endif %}
         {% for tree_option in treestatus_select_trees_form.trees %}
         {% set tree = trees[tree_option.data] %}
-            <div class="box">
+            <div class="select-trees-box box">
                 <div class="columns">
                     {% if is_user_authenticated_TODO() %}
                         <div class="column is-1">

--- a/landoui/templates/treestatus/trees.html
+++ b/landoui/templates/treestatus/trees.html
@@ -60,7 +60,7 @@
                     <div class="column">
                         {% if tree.reason %}
                             <p>Reason: <b>{{ tree.reason }}</b></p>
-                            <p>Reason category: <b>{{ tree.tags[0] }}</b></p>
+                            <p>Reason category: <b>{{ tree.tags[0] | reason_category_to_display }}</b></p>
                         {% endif %}
                     </div>
                     <div class="column">

--- a/landoui/templates/treestatus/update_trees.html
+++ b/landoui/templates/treestatus/update_trees.html
@@ -4,25 +4,18 @@
     file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% extends "partials/layout.html" %}
-{% block page_title %}Treestatus{% endblock %}
-
 {% block main %}
-<main class="Treestatus container fullhd">
-
-    {% include "treestatus/recent_changes.html" %}
-
-    <h1>Treestatus: Update trees</h1>
-    <form action="{{ url_for("treestatus.update_treestatus") }}" method="post">
-        <div class="box">
+<div class="modal update-trees-modal">
+    <div class="modal-background"></div>
+    <div class="modal-card">
+        <header class="modal-card-head">
+            <p class="modal-card-title">Update trees</p>
+        </header>
+        <section class="modal-card-body">
             {{ treestatus_update_trees_form.csrf_token }}
             <div class="block content">
                 <div>You are about to update the following trees:</div>
-                <ul>
-                    {% for tree in treestatus_update_trees_form.trees %}
-                    <li>{{ tree.data }} {{ tree }}</li>
-                    {% endfor %}
-                </ul>
+                <ul class="update-trees-list"></ul>
             </div>
             <div class="field">
                 <label class="label">{{ treestatus_update_trees_form.status.label }}</label>
@@ -54,11 +47,11 @@
                 <div class="control">{{ treestatus_update_trees_form.message_of_the_day(class="input") }}</div>
                 <p class="help">Optional</p>
             </div>
-            <div class="field">
-                <button class="button is-primary" title="Update Tree">Update trees</button>
-            </div>
-        </div>
-    </form>
-
-</main>
+        </section>
+        <footer class="modal-card-foot">
+            <button class="button is-primary" title="Update Tree">Update trees</button>
+        </footer>
+    </div>
+    <button class="modal-close is-large update-trees-modal-close" aria-label="close" type="button"></button>
+</div>
 {% endblock %}

--- a/landoui/templates/treestatus/update_trees.html
+++ b/landoui/templates/treestatus/update_trees.html
@@ -42,10 +42,10 @@
             </div>
             <div class="field">
                 <label class="checkbox label">
-                    {{ treestatus_update_trees_form.remember_this_change.label }}
+                    {{ treestatus_update_trees_form.remember.label }}
                 </label>
                 <div class="control">
-                    {{ treestatus_update_trees_form.remember_this_change(input="class", checked=True) }}
+                    {{ treestatus_update_trees_form.remember(input="class", checked=True) }}
                     Remember this change to undo later.
                 </div>
             </div>

--- a/landoui/templates/treestatus/update_trees.html
+++ b/landoui/templates/treestatus/update_trees.html
@@ -45,7 +45,7 @@
                     {{ treestatus_update_trees_form.remember_this_change.label }}
                 </label>
                 <div class="control">
-                    {{ treestatus_update_trees_form.remember_this_change(input="class") }}
+                    {{ treestatus_update_trees_form.remember_this_change(input="class", checked=True) }}
                     Remember this change to undo later.
                 </div>
             </div>

--- a/landoui/templates/treestatus/update_trees.html
+++ b/landoui/templates/treestatus/update_trees.html
@@ -1,0 +1,64 @@
+{#
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#}
+
+{% extends "partials/layout.html" %}
+{% block page_title %}Treestatus{% endblock %}
+
+{% block main %}
+<main class="Treestatus container fullhd">
+
+    {% include "treestatus/recent_changes.html" %}
+
+    <h1>Treestatus: Update trees</h1>
+    <form action="{{ url_for("treestatus.update_treestatus") }}" method="post">
+        <div class="box">
+            {{ treestatus_update_trees_form.csrf_token }}
+            <div class="block content">
+                <div>You are about to update the following trees:</div>
+                <ul>
+                    {% for tree in treestatus_update_trees_form.trees %}
+                    <li>{{ tree.data }} {{ tree }}</li>
+                    {% endfor %}
+                </ul>
+            </div>
+            <div class="field">
+                <label class="label">{{ treestatus_update_trees_form.status.label }}</label>
+                <div class="control is-expanded">
+                    <div class="select is-fullwidth">{{ treestatus_update_trees_form.status() }}</div>
+                </div>
+            </div>
+            <div class="field">
+                <label class="label">{{ treestatus_update_trees_form.reason_category.label }}</label>
+                <div class="control is-expanded">
+                    <div class="select is-fullwidth">{{ treestatus_update_trees_form.reason_category() }}</div>
+                </div>
+            </div>
+            <div class="field">
+                <label class="label">{{ treestatus_update_trees_form.reason.label }}</label>
+                <div class="control">{{ treestatus_update_trees_form.reason(class="input") }}</div>
+            </div>
+            <div class="field">
+                <label class="checkbox label">
+                    {{ treestatus_update_trees_form.remember_this_change.label }}
+                </label>
+                <div class="control">
+                    {{ treestatus_update_trees_form.remember_this_change(input="class") }}
+                    Remember this change to undo later.
+                </div>
+            </div>
+            <div class="field">
+                <label class="label">{{ treestatus_update_trees_form.message_of_the_day.label }}</label>
+                <div class="control">{{ treestatus_update_trees_form.message_of_the_day(class="input") }}</div>
+                <p class="help">Optional</p>
+            </div>
+            <div class="field">
+                <button class="button is-primary" title="Update Tree">Update trees</button>
+            </div>
+        </div>
+    </form>
+
+</main>
+{% endblock %}

--- a/landoui/treestatus.py
+++ b/landoui/treestatus.py
@@ -330,7 +330,11 @@ def update_change(id: int):
 
 @treestatus_blueprint.route("/treestatus/log/<int:id>", methods=["POST"])
 def update_log(id: int):
-    """Handler for log updates."""
+    """Handler for log updates.
+
+    This function handles form submissions for updates to individual log entries
+    in the per-tree log view.
+    """
     api = LandoAPI.from_environment()
 
     log_update_form = TreeStatusLogUpdateForm()

--- a/landoui/treestatus.py
+++ b/landoui/treestatus.py
@@ -228,7 +228,7 @@ def new_tree_handler(api: LandoAPI, form: TreeStatusNewTreeForm):
 
 @treestatus_blueprint.route("/treestatus/<tree>/", methods=["GET"])
 def treestatus_tree(tree: str):
-    """Display the log of statuses for a given tree."""
+    """Display the log of statuses for an individual tree."""
     api = LandoAPI.from_environment()
 
     logs_response = api.request("GET", f"treestatus/trees/{tree}/logs")

--- a/landoui/treestatus.py
+++ b/landoui/treestatus.py
@@ -2,10 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from typing import (
-    Optional,
-)
-
 from flask import (
     Blueprint,
     flash,
@@ -235,20 +231,6 @@ def treestatus_tree(tree: str):
         recent_changes_stack=recent_changes_stack,
         tree=tree,
     )
-
-
-def build_update_json_body(
-    reason: Optional[str], reason_category: Optional[str]
-) -> dict:
-    """Return a `dict` for use as a JSON body in a log/change update."""
-    json_body = {}
-
-    json_body["reason"] = reason
-
-    if reason_category and ReasonCategory.is_valid_for_backend(reason_category):
-        json_body["tags"] = [reason_category]
-
-    return json_body
 
 
 @treestatus_blueprint.route("/treestatus/stack/<int:id>", methods=["POST"])

--- a/landoui/treestatus.py
+++ b/landoui/treestatus.py
@@ -288,6 +288,7 @@ def update_log(id: int):
         api.request(
             "PATCH",
             f"treestatus/log/{id}",
+            require_auth0=True,
             json=json_body,
         )
     except LandoAPIError as exc:

--- a/landoui/treestatus.py
+++ b/landoui/treestatus.py
@@ -78,7 +78,12 @@ def build_recent_changes_stack(
 
 @treestatus_blueprint.route("/treestatus/", methods=["GET"])
 def treestatus():
-    """Display the status of all the current trees."""
+    """Display the status of all the current trees.
+
+    This view is the main landing page for Treestatus. The view is a list of all trees
+    and their current statuses. The view of all trees is a form where each tree can be
+    selected, and "Update trees" passes the selection along to the tree updating form.
+    """
     api = LandoAPI.from_environment()
 
     treestatus_select_trees_form = TreeStatusSelectTreesForm()

--- a/landoui/treestatus.py
+++ b/landoui/treestatus.py
@@ -272,7 +272,12 @@ def build_update_json_body(
 
 @treestatus_blueprint.route("/treestatus/stack/<int:id>", methods=["POST"])
 def update_change(id: int):
-    """Handler for stack updates."""
+    """Handler for stack updates.
+
+    This function handles form submissions for updates to entries in the recent changes
+    stack. This includes pressing the "restore" or "discard" buttons, as well as updates
+    to the reason and reason category after pressing "edit" and "update".
+    """
     api = LandoAPI.from_environment()
     recent_changes_form = TreeStatusRecentChangesForm()
 

--- a/landoui/treestatus.py
+++ b/landoui/treestatus.py
@@ -191,7 +191,7 @@ def new_tree_handler(api: LandoAPI, form: TreeStatusNewTreeForm):
         flash(
             f"Could not create new tree: {exc.detail}. Please try again later.", "error"
         )
-        return redirect(request.referrer), 500
+        return redirect(request.referrer), 303
 
     flash(f"New tree {tree} created successfully.")
     return redirect(url_for("treestatus.treestatus"))
@@ -309,7 +309,7 @@ def update_change(id: int):
             f"Could not modify recent change: {exc.detail}. Please try again later.",
             "error",
         )
-        return redirect(request.referrer), 500
+        return redirect(request.referrer), 303
 
     flash(flash_message)
     return redirect(request.referrer)
@@ -345,7 +345,7 @@ def update_log(id: int):
             f"Could not modify log entry: {exc.detail}. Please try again later.",
             "error",
         )
-        return redirect(request.referrer), 500
+        return redirect(request.referrer), 303
 
     flash("Log entry updated.")
     return redirect(request.referrer)

--- a/landoui/treestatus.py
+++ b/landoui/treestatus.py
@@ -90,6 +90,15 @@ def treestatus():
         # Submit the form.
         return update_treestatus(api, treestatus_update_trees_form)
 
+    if (
+        treestatus_update_trees_form.is_submitted()
+        and not treestatus_update_trees_form.validate()
+    ):
+        # Flash form submission errors.
+        for errors in treestatus_update_trees_form.errors.values():
+            for error in errors:
+                flash(error, "warning")
+
     trees_response = api.request("GET", "treestatus/trees")
     trees = trees_response.get("result")
 

--- a/landoui/treestatus.py
+++ b/landoui/treestatus.py
@@ -193,7 +193,7 @@ def update_treestatus():
             raise exc
 
         flash(f"Could not update trees: {exc.detail}. Please try again later.", "error")
-        return redirect(request.referrer), 500
+        return redirect(request.referrer), 303
 
     # Redirect to the main Treestatus page.
     flash("Tree statuses updated successfully.")

--- a/landoui/treestatus.py
+++ b/landoui/treestatus.py
@@ -306,7 +306,7 @@ def update_change(id: int):
         method = "DELETE"
         request_args = {"params": {"revert": 1}}
 
-        flash_message = "Statuses change restored."
+        flash_message = "Status change restored."
     elif discard:
         # Discard is a DELETE without a status revert.
         method = "DELETE"

--- a/landoui/treestatus.py
+++ b/landoui/treestatus.py
@@ -27,6 +27,7 @@ from landoui.landoapi import (
 )
 from landoui.forms import (
     ReasonCategory,
+    TreeCategory,
     TreeStatusLogUpdateForm,
     TreeStatusNewTreeForm,
     TreeStatusRecentChangesForm,
@@ -84,8 +85,10 @@ def treestatus():
     trees_response = api.request("GET", "treestatus/trees")
     trees = trees_response.get("result")
 
-    for tree in trees:
-        treestatus_select_trees_form.trees.append_entry(tree)
+    ordered_tree_choices = sorted(trees.values(), key=TreeCategory.sort_trees)
+
+    for tree in ordered_tree_choices:
+        treestatus_select_trees_form.trees.append_entry(tree["tree"])
 
     recent_changes_stack = build_recent_changes_stack(api)
 
@@ -208,6 +211,7 @@ def new_tree_handler(api: LandoAPI, form: TreeStatusNewTreeForm):
     """Handler for the new tree form."""
     # Retrieve data from the form.
     tree = form.tree.data
+    tree_category = form.category.data
 
     try:
         api.request(
@@ -217,6 +221,7 @@ def new_tree_handler(api: LandoAPI, form: TreeStatusNewTreeForm):
             # require_auth0=True,
             json={
                 "tree": tree,
+                "category": tree_category,
                 # Trees are open on creation.
                 "status": "open",
                 "reason": "",

--- a/landoui/treestatus.py
+++ b/landoui/treestatus.py
@@ -66,8 +66,6 @@ def build_recent_changes_stack(
                     if change["trees"][0]["last_state"]["current_tags"]
                     else ReasonCategory.NO_CATEGORY.value
                 ),
-                who=change["who"],
-                when=change["when"],
             ),
             change,
         )

--- a/landoui/treestatus.py
+++ b/landoui/treestatus.py
@@ -150,7 +150,7 @@ def update_treestatus():
     reason = treestatus_update_trees_form.reason.data
     message_of_the_day = treestatus_update_trees_form.message_of_the_day.data
     reason_category = treestatus_update_trees_form.reason_category.data
-    remember = treestatus_update_trees_form.remember_this_change.data
+    remember = treestatus_update_trees_form.remember.data
 
     # Avoid setting tags for invalid values.
     tags = (

--- a/landoui/treestatus.py
+++ b/landoui/treestatus.py
@@ -104,7 +104,12 @@ def treestatus():
 
 @treestatus_blueprint.route("/treestatus/update", methods=["POST"])
 def update_treestatus_form():
-    """Web UI for the tree status updating form."""
+    """Web UI for the tree status updating form.
+
+    This form is rendered when the "Update trees" button is clicked on the main Treestatus
+    page. The Trees that were selected on the main page are forwarded to this form, where
+    we validate that at least 1 tree was selected for updating.
+    """
     api = LandoAPI.from_environment()
 
     treestatus_select_trees_form = TreeStatusSelectTreesForm()

--- a/landoui/treestatus.py
+++ b/landoui/treestatus.py
@@ -136,7 +136,13 @@ def update_treestatus_form():
 
 @treestatus_blueprint.route("/treestatus/update_handler", methods=["POST"])
 def update_treestatus():
-    """Handler for the tree status updating form."""
+    """Handler for the tree status updating form.
+
+    This function handles form submission for the status updating form. Validate
+    the form submission and submit a request to LandoAPI, redirecting to the main
+    Treestatus page on success. Display an error message and return to the form if
+    the status updating rules were broken or the API returned an error.
+    """
     api = LandoAPI.from_environment()
     treestatus_update_trees_form = TreeStatusUpdateTreesForm()
 

--- a/landoui/treestatus.py
+++ b/landoui/treestatus.py
@@ -1,0 +1,391 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from typing import (
+    Optional,
+)
+
+from flask import (
+    Blueprint,
+    current_app,
+    flash,
+    redirect,
+    render_template,
+    request,
+    session,
+    url_for,
+)
+
+from landoui.helpers import (
+    get_phabricator_api_token,
+    set_last_local_referrer,
+)
+from landoui.landoapi import (
+    LandoAPI,
+    LandoAPIError,
+)
+from landoui.forms import (
+    ReasonCategory,
+    TreeStatusLogUpdateForm,
+    TreeStatusNewTreeForm,
+    TreeStatusRecentChangesForm,
+    TreeStatusSelectTreesForm,
+    TreeStatusUpdateTreesForm,
+)
+
+treestatus_blueprint = Blueprint("treestatus", __name__)
+treestatus_blueprint.before_request(set_last_local_referrer)
+
+
+def build_recent_changes_stack(
+    api: LandoAPI,
+) -> list[tuple[TreeStatusRecentChangesForm, dict]]:
+    """Build the recent changes stack object."""
+    try:
+        response = api.request(
+            "GET",
+            "treestatus/stack",
+        )
+    except LandoAPIError as exc:
+        if not exc.detail:
+            raise exc
+
+        flash(f"Could not retrieve recent changes stack: {exc.detail}.", "error")
+        return []
+
+    return [
+        (
+            TreeStatusRecentChangesForm(
+                id=change["id"],
+                reason=change["reason"],
+                reason_category=change["trees"][0]["last_state"]["current_tags"][0],
+                who=change["who"],
+                when=change["when"],
+            ),
+            change,
+        )
+        for change in response["result"]
+    ]
+
+
+@treestatus_blueprint.route("/treestatus/", methods=["GET"])
+def treestatus():
+    """Display the status of all the current trees."""
+    token = get_phabricator_api_token()
+    api = LandoAPI(
+        current_app.config["LANDO_API_URL"],
+        auth0_access_token=session.get("access_token"),
+        phabricator_api_token=token,
+    )
+
+    treestatus_select_trees_form = TreeStatusSelectTreesForm()
+
+    trees_response = api.request("GET", "treestatus/trees")
+    trees = trees_response.get("result")
+
+    for tree in trees:
+        treestatus_select_trees_form.trees.append_entry(tree)
+
+    recent_changes_stack = build_recent_changes_stack(api)
+
+    return render_template(
+        "treestatus/trees.html",
+        recent_changes_stack=recent_changes_stack,
+        trees=trees,
+        treestatus_select_trees_form=treestatus_select_trees_form,
+    )
+
+
+@treestatus_blueprint.route("/treestatus/update", methods=["POST"])
+def update_treestatus_form():
+    """Web UI for the tree status updating form."""
+    token = get_phabricator_api_token()
+    api = LandoAPI(
+        current_app.config["LANDO_API_URL"],
+        auth0_access_token=session.get("access_token"),
+        phabricator_api_token=token,
+    )
+
+    treestatus_select_trees_form = TreeStatusSelectTreesForm()
+    if not treestatus_select_trees_form.validate_on_submit():
+        # Validate the tree selection form was submitted with at least one
+        # tree selected.
+        for errors in treestatus_select_trees_form.errors.values():
+            for error in errors:
+                flash(error, "warning")
+
+        return redirect(request.referrer)
+
+    treestatus_update_trees_form = TreeStatusUpdateTreesForm()
+
+    recent_changes_stack = build_recent_changes_stack(api)
+
+    return render_template(
+        "treestatus/update_trees.html",
+        recent_changes_stack=recent_changes_stack,
+        treestatus_update_trees_form=treestatus_update_trees_form,
+    )
+
+
+@treestatus_blueprint.route("/treestatus/update_handler", methods=["POST"])
+def update_treestatus():
+    """Handler for the tree status updating form."""
+    api = LandoAPI(
+        current_app.config["LANDO_API_URL"],
+        auth0_access_token=session.get("access_token"),
+        phabricator_api_token=get_phabricator_api_token(),
+    )
+    treestatus_update_trees_form = TreeStatusUpdateTreesForm()
+
+    if not treestatus_update_trees_form.validate_on_submit():
+        for errors in treestatus_update_trees_form.errors.values():
+            for error in errors:
+                flash(error, "warning")
+
+        # Return the result of re-rendering the form, so the current state of
+        # the form is preserved.
+        return update_treestatus_form()
+
+    # Retrieve data from the form.
+    trees = treestatus_update_trees_form.trees.data
+    status = treestatus_update_trees_form.status.data
+    reason = treestatus_update_trees_form.reason.data
+    message_of_the_day = treestatus_update_trees_form.message_of_the_day.data
+    reason_category = treestatus_update_trees_form.reason_category.data
+    remember = treestatus_update_trees_form.remember_this_change.data
+
+    try:
+        api.request(
+            "PATCH",
+            "treestatus/trees",
+            require_auth0=True,
+            json={
+                "trees": trees,
+                "status": status,
+                "reason": reason,
+                "message_of_the_day": message_of_the_day,
+                "tags": [reason_category],
+                "remember": remember,
+            },
+        )
+    except LandoAPIError as exc:
+        if not exc.detail:
+            raise exc
+
+        flash(f"Could not update trees: {exc.detail}. Please try again later.", "error")
+        return redirect(request.referrer), 500
+
+    # Redirect to the main Treestatus page.
+    flash("Tree statuses updated successfully.")
+    return redirect(url_for("treestatus.treestatus"))
+
+
+@treestatus_blueprint.route("/treestatus/new_tree/", methods=["GET", "POST"])
+def new_tree():
+    """View for the new tree form."""
+    api = LandoAPI(
+        current_app.config["LANDO_API_URL"],
+        auth0_access_token=session.get("access_token"),
+        phabricator_api_token=get_phabricator_api_token(),
+    )
+    treestatus_new_tree_form = TreeStatusNewTreeForm()
+
+    if treestatus_new_tree_form.validate_on_submit():
+        return new_tree_handler(api, treestatus_new_tree_form)
+
+    recent_changes_stack = build_recent_changes_stack(api)
+
+    return render_template(
+        "treestatus/new_tree.html",
+        treestatus_new_tree_form=treestatus_new_tree_form,
+        recent_changes_stack=recent_changes_stack,
+    )
+
+
+def new_tree_handler(api: LandoAPI, form: TreeStatusNewTreeForm):
+    """Handler for the new tree form."""
+    # Retrieve data from the form.
+    tree = form.tree.data
+
+    try:
+        api.request(
+            "PUT",
+            f"treestatus/trees/{tree}",
+            require_auth0=True,
+            json={
+                "tree": tree,
+                # Trees are open on creation.
+                "status": "open",
+                "reason": "",
+                "message_of_the_day": "",
+            },
+        )
+    except LandoAPIError as exc:
+        if not exc.detail:
+            raise exc
+
+        flash(
+            f"Could not create new tree: {exc.detail}. Please try again later.", "error"
+        )
+        return redirect(request.referrer), 500
+
+    flash(f"New tree {tree} created successfully.")
+    return redirect(url_for("treestatus.treestatus"))
+
+
+@treestatus_blueprint.route("/treestatus/<tree>/", methods=["GET"])
+def treestatus_tree(tree: str):
+    """Display the log of statuses for a given tree."""
+    token = get_phabricator_api_token()
+    api = LandoAPI(
+        current_app.config["LANDO_API_URL"],
+        auth0_access_token=session.get("access_token"),
+        phabricator_api_token=token,
+    )
+
+    logs_response = api.request("GET", f"treestatus/trees/{tree}/logs")
+    logs = logs_response.get("result")
+    if not logs:
+        flash(
+            f"Could not retrieve status logs for {tree} from Lando, try again later.",
+            "error",
+        )
+        return redirect(request.referrer)
+
+    current_log = logs[0]
+
+    logs = [
+        (
+            TreeStatusLogUpdateForm(
+                reason=log["reason"],
+                reason_category=log["tags"][0]
+                if log["tags"]
+                else ReasonCategory.NO_CATEGORY.value,
+            ),
+            log,
+        )
+        for log in logs
+    ]
+
+    recent_changes_stack = build_recent_changes_stack(api)
+
+    return render_template(
+        "treestatus/log.html",
+        current_log=current_log,
+        logs=logs,
+        recent_changes_stack=recent_changes_stack,
+        tree=tree,
+    )
+
+
+def build_update_json_body(
+    reason: Optional[str], reason_category: Optional[str]
+) -> dict:
+    """Return a `dict` for use as a JSON body in a log/change update."""
+    json_body = {}
+
+    json_body["reason"] = reason
+
+    if reason_category and ReasonCategory.is_valid_reason_category(reason_category):
+        json_body["tags"] = [reason_category]
+
+    return json_body
+
+
+@treestatus_blueprint.route("/treestatus/stack/<int:id>", methods=["POST"])
+def update_change(id: int):
+    """Handler for stack updates."""
+    api = LandoAPI(
+        current_app.config["LANDO_API_URL"],
+        auth0_access_token=session.get("access_token"),
+        phabricator_api_token=get_phabricator_api_token(),
+    )
+    recent_changes_form = TreeStatusRecentChangesForm()
+
+    restore = recent_changes_form.restore.data
+    update = recent_changes_form.update.data
+    discard = recent_changes_form.discard.data
+
+    if restore:
+        # Restore is a DELETE with a status revert.
+        method = "DELETE"
+        request_args = {"params": {"revert": 1}}
+
+        flash_message = "Statuses change restored."
+    elif discard:
+        # Discard is a DELETE without a status revert.
+        method = "DELETE"
+        request_args = {"params": {"revert": 0}}
+
+        flash_message = "Status change discarded."
+    elif update:
+        # Update is a PATCH with any changed attributes passed in the body.
+        method = "PATCH"
+
+        reason = recent_changes_form.reason.data
+        reason_category = recent_changes_form.reason_category.data
+
+        request_args = {"json": build_update_json_body(reason, reason_category)}
+
+        flash_message = "Status change updated."
+    else:
+        # This should not happen, but just in case.
+        flash("Invalid submit input on change update form.", "error")
+        return redirect(request.referrer)
+
+    try:
+        api.request(
+            method,
+            f"treestatus/stack/{id}",
+            require_auth0=True,
+            **request_args,
+        )
+    except LandoAPIError as exc:
+        if not exc.detail:
+            raise exc
+
+        flash(
+            f"Could not modify recent change: {exc.detail}. Please try again later.",
+            "error",
+        )
+        return redirect(request.referrer), 500
+
+    flash(flash_message)
+    return redirect(request.referrer)
+
+
+@treestatus_blueprint.route("/treestatus/log/<int:id>", methods=["POST"])
+def update_log(id: int):
+    """Handler for log updates."""
+    api = LandoAPI(
+        current_app.config["LANDO_API_URL"],
+        auth0_access_token=session.get("access_token"),
+        phabricator_api_token=get_phabricator_api_token(),
+    )
+
+    log_update_form = TreeStatusLogUpdateForm()
+
+    reason = log_update_form.reason.data
+    reason_category = log_update_form.reason_category.data
+
+    json_body = build_update_json_body(reason, reason_category)
+
+    try:
+        api.request(
+            "PATCH",
+            f"treestatus/log/{id}",
+            json=json_body,
+        )
+    except LandoAPIError as exc:
+        if not exc.detail:
+            raise exc
+
+        flash(
+            f"Could not modify log entry: {exc.detail}. Please try again later.",
+            "error",
+        )
+        return redirect(request.referrer), 500
+
+    flash("Log entry updated.")
+    return redirect(request.referrer)

--- a/landoui/treestatus.py
+++ b/landoui/treestatus.py
@@ -173,8 +173,7 @@ def update_treestatus():
         api.request(
             "PATCH",
             "treestatus/trees",
-            # TODO re-add auth0 requirement.
-            # require_auth0=True,
+            require_auth0=True,
             json={
                 "trees": trees,
                 "status": status,
@@ -228,8 +227,7 @@ def new_tree_handler(api: LandoAPI, form: TreeStatusNewTreeForm):
         api.request(
             "PUT",
             f"treestatus/trees/{tree}",
-            # TODO re-enable auth0 requirement.
-            # require_auth0=True,
+            require_auth0=True,
             json={
                 "tree": tree,
                 "category": tree_category,
@@ -356,8 +354,7 @@ def update_change(id: int):
         api.request(
             method,
             f"treestatus/stack/{id}",
-            # TODO re-enable auth0 requirement.
-            # require_auth0=True,
+            require_auth0=True,
             **request_args,
         )
     except LandoAPIError as exc:

--- a/landoui/treestatus.py
+++ b/landoui/treestatus.py
@@ -8,17 +8,14 @@ from typing import (
 
 from flask import (
     Blueprint,
-    current_app,
     flash,
     redirect,
     render_template,
     request,
-    session,
     url_for,
 )
 
 from landoui.helpers import (
-    get_phabricator_api_token,
     set_last_local_referrer,
 )
 from landoui.landoapi import (
@@ -82,12 +79,7 @@ def build_recent_changes_stack(
 @treestatus_blueprint.route("/treestatus/", methods=["GET"])
 def treestatus():
     """Display the status of all the current trees."""
-    token = get_phabricator_api_token()
-    api = LandoAPI(
-        current_app.config["LANDO_API_URL"],
-        auth0_access_token=session.get("access_token"),
-        phabricator_api_token=token,
-    )
+    api = LandoAPI.from_environment()
 
     treestatus_select_trees_form = TreeStatusSelectTreesForm()
 
@@ -113,12 +105,7 @@ def treestatus():
 @treestatus_blueprint.route("/treestatus/update", methods=["POST"])
 def update_treestatus_form():
     """Web UI for the tree status updating form."""
-    token = get_phabricator_api_token()
-    api = LandoAPI(
-        current_app.config["LANDO_API_URL"],
-        auth0_access_token=session.get("access_token"),
-        phabricator_api_token=token,
-    )
+    api = LandoAPI.from_environment()
 
     treestatus_select_trees_form = TreeStatusSelectTreesForm()
     if not treestatus_select_trees_form.validate_on_submit():
@@ -145,11 +132,7 @@ def update_treestatus_form():
 @treestatus_blueprint.route("/treestatus/update_handler", methods=["POST"])
 def update_treestatus():
     """Handler for the tree status updating form."""
-    api = LandoAPI(
-        current_app.config["LANDO_API_URL"],
-        auth0_access_token=session.get("access_token"),
-        phabricator_api_token=get_phabricator_api_token(),
-    )
+    api = LandoAPI.from_environment()
     treestatus_update_trees_form = TreeStatusUpdateTreesForm()
 
     if not treestatus_update_trees_form.validate_on_submit():
@@ -205,11 +188,7 @@ def update_treestatus():
 @treestatus_blueprint.route("/treestatus/new_tree/", methods=["GET", "POST"])
 def new_tree():
     """View for the new tree form."""
-    api = LandoAPI(
-        current_app.config["LANDO_API_URL"],
-        auth0_access_token=session.get("access_token"),
-        phabricator_api_token=get_phabricator_api_token(),
-    )
+    api = LandoAPI.from_environment()
     treestatus_new_tree_form = TreeStatusNewTreeForm()
 
     if treestatus_new_tree_form.validate_on_submit():
@@ -261,12 +240,7 @@ def new_tree_handler(api: LandoAPI, form: TreeStatusNewTreeForm):
 @treestatus_blueprint.route("/treestatus/<tree>/", methods=["GET"])
 def treestatus_tree(tree: str):
     """Display the log of statuses for a given tree."""
-    token = get_phabricator_api_token()
-    api = LandoAPI(
-        current_app.config["LANDO_API_URL"],
-        auth0_access_token=session.get("access_token"),
-        phabricator_api_token=token,
-    )
+    api = LandoAPI.from_environment()
 
     logs_response = api.request("GET", f"treestatus/trees/{tree}/logs")
     logs = logs_response.get("result")
@@ -321,11 +295,7 @@ def build_update_json_body(
 @treestatus_blueprint.route("/treestatus/stack/<int:id>", methods=["POST"])
 def update_change(id: int):
     """Handler for stack updates."""
-    api = LandoAPI(
-        current_app.config["LANDO_API_URL"],
-        auth0_access_token=session.get("access_token"),
-        phabricator_api_token=get_phabricator_api_token(),
-    )
+    api = LandoAPI.from_environment()
     recent_changes_form = TreeStatusRecentChangesForm()
 
     restore = recent_changes_form.restore.data
@@ -383,11 +353,7 @@ def update_change(id: int):
 @treestatus_blueprint.route("/treestatus/log/<int:id>", methods=["POST"])
 def update_log(id: int):
     """Handler for log updates."""
-    api = LandoAPI(
-        current_app.config["LANDO_API_URL"],
-        auth0_access_token=session.get("access_token"),
-        phabricator_api_token=get_phabricator_api_token(),
-    )
+    api = LandoAPI.from_environment()
 
     log_update_form = TreeStatusLogUpdateForm()
 

--- a/landoui/treestatus.py
+++ b/landoui/treestatus.py
@@ -76,7 +76,8 @@ def treestatus():
 
     This view is the main landing page for Treestatus. The view is a list of all trees
     and their current statuses. The view of all trees is a form where each tree can be
-    selected, and "Update trees" passes the selection along to the tree updating form.
+    selected, and clicking "Update trees" opens a modal which presents the tree updating
+    form.
     """
     api = LandoAPI.from_environment()
 

--- a/landoui/treestatus.py
+++ b/landoui/treestatus.py
@@ -56,7 +56,9 @@ def get_recent_changes_stack(api: LandoAPI) -> list[dict]:
     return response["result"]
 
 
-def build_recent_changes_stack(recent_changes_data: list[dict]) -> list[tuple[TreeStatusRecentChangesForm, dict]]:
+def build_recent_changes_stack(
+    recent_changes_data: list[dict],
+) -> list[tuple[TreeStatusRecentChangesForm, dict]]:
     """Build the recent changes stack object."""
     return [
         (

--- a/landoui/treestatus.py
+++ b/landoui/treestatus.py
@@ -159,7 +159,8 @@ def update_treestatus():
         api.request(
             "PATCH",
             "treestatus/trees",
-            require_auth0=True,
+            # TODO re-add auth0 requirement.
+            # require_auth0=True,
             json={
                 "trees": trees,
                 "status": status,
@@ -212,7 +213,8 @@ def new_tree_handler(api: LandoAPI, form: TreeStatusNewTreeForm):
         api.request(
             "PUT",
             f"treestatus/trees/{tree}",
-            require_auth0=True,
+            # TODO re-enable auth0 requirement.
+            # require_auth0=True,
             json={
                 "tree": tree,
                 # Trees are open on creation.
@@ -338,7 +340,8 @@ def update_change(id: int):
         api.request(
             method,
             f"treestatus/stack/{id}",
-            require_auth0=True,
+            # TODO re-enable auth0 requirement.
+            # require_auth0=True,
             **request_args,
         )
     except LandoAPIError as exc:

--- a/landoui/treestatus.py
+++ b/landoui/treestatus.py
@@ -144,34 +144,12 @@ def update_treestatus():
         # the form is preserved.
         return update_treestatus_form()
 
-    # Retrieve data from the form.
-    trees = treestatus_update_trees_form.trees.data
-    status = treestatus_update_trees_form.status.data
-    reason = treestatus_update_trees_form.reason.data
-    message_of_the_day = treestatus_update_trees_form.message_of_the_day.data
-    reason_category = treestatus_update_trees_form.reason_category.data
-    remember = treestatus_update_trees_form.remember.data
-
-    # Avoid setting tags for invalid values.
-    tags = (
-        [reason_category]
-        if ReasonCategory.is_valid_for_backend(reason_category)
-        else []
-    )
-
     try:
         api.request(
             "PATCH",
             "treestatus/trees",
             require_auth0=True,
-            json={
-                "trees": trees,
-                "status": status,
-                "reason": reason,
-                "message_of_the_day": message_of_the_day,
-                "tags": tags,
-                "remember": remember,
-            },
+            json=treestatus_update_trees_form.to_submitted_json(),
         )
     except LandoAPIError as exc:
         if not exc.detail:

--- a/landoui/wsgi.py
+++ b/landoui/wsgi.py
@@ -18,5 +18,6 @@ app = create_app(
     use_https=str2bool(os.getenv("USE_HTTPS", 1)),
     enable_asset_pipeline=True,
     lando_api_url=os.getenv("LANDO_API_URL"),
+    treestatus_url=os.getenv("TREESTATUS_URL"),
     debug=str2bool(os.getenv("DEBUG", 0)),
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,7 +44,13 @@ def api_url():
 
 
 @pytest.fixture
-def app(versionfile, docker_env_vars, api_url):
+def treestatus_url():
+    """A string holding the Treestatus API base URL. Useful for request mocking."""
+    return "http://treestatus.test"
+
+
+@pytest.fixture
+def app(versionfile, docker_env_vars, api_url, treestatus_url):
     app = create_app(
         version_path=versionfile.strpath,
         secret_key=str(binascii.b2a_hex(os.urandom(15))),
@@ -54,6 +60,7 @@ def app(versionfile, docker_env_vars, api_url):
         use_https=False,
         enable_asset_pipeline=False,
         lando_api_url=api_url,
+        treestatus_url=treestatus_url,
         debug=True,
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,8 +31,7 @@ def docker_env_vars(monkeypatch):
     monkeypatch.setenv("SESSION_COOKIE_SECURE", "0")
     monkeypatch.setenv("USE_HTTPS", "0")
     monkeypatch.setenv("LANDO_API_URL", "http://lando-api.test:8888")
-    # TODO correct?
-    monkeypatch.setenv("LANDO_API_URL", "http://treestatus.test:8888")
+    monkeypatch.setenv("TREESTATUS_URL", "http://treestatus.test:8888")
     monkeypatch.setenv("SENTRY_DSN", "")
     monkeypatch.setenv("LOG_LEVEL", "DEBUG")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,8 @@ def docker_env_vars(monkeypatch):
     monkeypatch.setenv("SESSION_COOKIE_SECURE", "0")
     monkeypatch.setenv("USE_HTTPS", "0")
     monkeypatch.setenv("LANDO_API_URL", "http://lando-api.test:8888")
+    # TODO correct?
+    monkeypatch.setenv("LANDO_API_URL", "http://treestatus.test:8888")
     monkeypatch.setenv("SENTRY_DSN", "")
     monkeypatch.setenv("LOG_LEVEL", "DEBUG")
 

--- a/tests/test_treestatus.py
+++ b/tests/test_treestatus.py
@@ -4,6 +4,7 @@
 
 from landoui.treestatus import (
     build_recent_changes_stack,
+    build_update_json_body,
 )
 
 
@@ -50,7 +51,26 @@ def test_build_recent_changes_stack(app):
 
 
 def test_build_update_json_body():
-    pass
+    assert build_update_json_body(None, None) == {
+        "reason": None,
+    }
+
+    assert build_update_json_body("blah", None) == {
+        "reason": "blah",
+    }
+
+    assert build_update_json_body("blah", "") == {
+        "reason": "blah",
+    }, "`tags` should not be set for empty reason category."
+
+    assert build_update_json_body("blah", "asdf") == {
+        "reason": "blah",
+    }, "`tags` should not be set for invalid reason category."
+
+    assert build_update_json_body("blah", "backlog") == {
+        "reason": "blah",
+        "tags": ["backlog"],
+    }, "`tags` should be set for valid reason category."
 
 
 def test_update_form_validate_trees():

--- a/tests/test_treestatus.py
+++ b/tests/test_treestatus.py
@@ -124,8 +124,51 @@ def test_update_form_validate_reason(app):
     ), "`closed` status with a reason is valid."
 
 
-def test_update_form_validate_reason_category():
-    pass
+def test_update_form_validate_reason_category(app):
+    form = TreeStatusUpdateTreesForm(
+        status="open",
+    )
+    assert (
+        form.validate_reason_category(form.reason_category) is None
+    ), "No validation required for `open` status."
+
+    form = TreeStatusUpdateTreesForm(
+        status="approval required",
+    )
+    assert (
+        form.validate_reason_category(form.reason_category) is None
+    ), "No validation required for `approval required` status."
+
+    # `closed` status requires a reason category.
+    form = TreeStatusUpdateTreesForm(
+        status="closed",
+    )
+    with pytest.raises(ValidationError):
+        form.validate_reason_category(form.reason_category)
+
+    # `closed` status requires a non-empty reason category.
+    form = TreeStatusUpdateTreesForm(
+        status="closed",
+        reason_category="",
+    )
+    with pytest.raises(ValidationError):
+        form.validate_reason_category(form.reason_category)
+
+    # `closed` status requires a valid reason category.
+    form = TreeStatusUpdateTreesForm(
+        status="closed",
+        reason_category="blah",
+    )
+    with pytest.raises(ValidationError):
+        form.validate_reason_category(form.reason_category)
+
+    form = TreeStatusUpdateTreesForm(
+        status="closed",
+        reason_category="backlog",
+    )
+    assert (
+        form.validate_reason_category(form.reason_category) is None
+    ), "`closed` status with valid reason category is valid."
 
 
 def test_update_form_to_submitted_json():

--- a/tests/test_treestatus.py
+++ b/tests/test_treestatus.py
@@ -97,16 +97,18 @@ def test_update_form_validate_reason(app):
     form = TreeStatusUpdateTreesForm(
         status="open",
     )
-    assert (
-        form.validate_reason(form.reason) is None
-    ), "No validation required for `open` status."
+    try:
+        form.validate_reason(form.reason)
+    except ValidationError as exc:
+        assert False, f"No validation required for `open` status: {exc}."
 
     form = TreeStatusUpdateTreesForm(
         status="approval required",
     )
-    assert (
-        form.validate_reason(form.reason) is None
-    ), "No validation required for `approval required` status."
+    try:
+        form.validate_reason(form.reason)
+    except ValidationError as exc:
+        assert False, f"No validation required for `approval required` status: {exc}."
 
     # `closed` status requires a reason.
     form = TreeStatusUpdateTreesForm(
@@ -119,25 +121,28 @@ def test_update_form_validate_reason(app):
         status="closed",
         reason="some reason",
     )
-    assert (
-        form.validate_reason(form.reason) is None
-    ), "`closed` status with a reason is valid."
+    try:
+        form.validate_reason(form.reason)
+    except ValidationError as exc:
+        assert False, f"`closed` status with a reason should be valid: {exc}"
 
 
 def test_update_form_validate_reason_category(app):
     form = TreeStatusUpdateTreesForm(
         status="open",
     )
-    assert (
-        form.validate_reason_category(form.reason_category) is None
-    ), "No validation required for `open` status."
+    try:
+        form.validate_reason_category(form.reason_category)
+    except ValidationError as exc:
+        assert False, f"No validation required for `open` status: {exc}."
 
     form = TreeStatusUpdateTreesForm(
         status="approval required",
     )
-    assert (
-        form.validate_reason_category(form.reason_category) is None
-    ), "No validation required for `approval required` status."
+    try:
+        form.validate_reason_category(form.reason_category)
+    except ValidationError as exc:
+        assert False, f"No validation required for `approval required` status: {exc}."
 
     # `closed` status requires a reason category.
     form = TreeStatusUpdateTreesForm(
@@ -166,9 +171,10 @@ def test_update_form_validate_reason_category(app):
         status="closed",
         reason_category="backlog",
     )
-    assert (
-        form.validate_reason_category(form.reason_category) is None
-    ), "`closed` status with valid reason category is valid."
+    try:
+        form.validate_reason_category(form.reason_category)
+    except ValidationError as exc:
+        assert False, f"`closed` status with valid reason category is valid: {exc}."
 
 
 def test_update_form_to_submitted_json(app):

--- a/tests/test_treestatus.py
+++ b/tests/test_treestatus.py
@@ -2,6 +2,13 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import pytest
+
+from wtforms.validators import ValidationError
+
+from landoui.forms import (
+    TreeStatusUpdateTreesForm,
+)
 from landoui.treestatus import (
     build_recent_changes_stack,
     build_update_json_body,
@@ -73,8 +80,17 @@ def test_build_update_json_body():
     }, "`tags` should be set for valid reason category."
 
 
-def test_update_form_validate_trees():
-    pass
+def test_update_form_validate_trees(app):
+    form = TreeStatusUpdateTreesForm()
+
+    # At least one tree is required.
+    with pytest.raises(ValidationError):
+        form.validate_trees(form.trees)
+
+    form.trees.append_entry("autoland")
+    assert (
+        form.validate_trees(form.trees) is None
+    ), "Form with a tree entry should be valid."
 
 
 def test_update_form_validate_reason():

--- a/tests/test_treestatus.py
+++ b/tests/test_treestatus.py
@@ -2,8 +2,51 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-def test_build_recent_changes_stack():
-    pass
+from landoui.treestatus import (
+    build_recent_changes_stack,
+)
+
+
+def test_build_recent_changes_stack(app):
+    recent_changes_data = [
+        {
+            "id": None,
+            "reason": "reason 2",
+            "trees": [{"last_state": {"current_tags": ["category 1"]}}],
+            "who": "user2",
+            "when": "now",
+        },
+        {
+            "id": 2,
+            "reason": "reason 2",
+            "trees": [{"last_state": {"current_tags": ["category 2"]}}],
+            "who": "user2",
+            "when": "now",
+        },
+        {
+            "id": 3,
+            "reason": "reason 3",
+            "trees": [{"last_state": {"current_tags": []}}],
+            "who": "user3",
+            "when": "now",
+        },
+    ]
+
+    recent_changes_stack = build_recent_changes_stack(recent_changes_data)
+
+    for form, data in recent_changes_stack:
+        assert form.id.data == data["id"]
+        assert form.reason.data == data["reason"]
+
+        if form.id.data == 3:
+            assert (
+                form.reason_category.data == ""
+            ), "Empty tags should set field to an empty string."
+        else:
+            assert (
+                form.reason_category.data
+                == data["trees"][0]["last_state"]["current_tags"][0]
+            )
 
 
 def test_build_update_json_body():

--- a/tests/test_treestatus.py
+++ b/tests/test_treestatus.py
@@ -1,0 +1,30 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+def test_build_recent_changes_stack():
+    pass
+
+
+def test_build_update_json_body():
+    pass
+
+
+def test_update_form_validate_trees():
+    pass
+
+
+def test_update_form_validate_reason():
+    pass
+
+
+def test_update_form_validate_reason_category():
+    pass
+
+
+def test_update_form_to_submitted_json():
+    pass
+
+
+def test_recent_changes_action():
+    pass

--- a/tests/test_treestatus.py
+++ b/tests/test_treestatus.py
@@ -93,8 +93,35 @@ def test_update_form_validate_trees(app):
     ), "Form with a tree entry should be valid."
 
 
-def test_update_form_validate_reason():
-    pass
+def test_update_form_validate_reason(app):
+    form = TreeStatusUpdateTreesForm(
+        status="open",
+    )
+    assert (
+        form.validate_reason(form.reason) is None
+    ), "No validation required for `open` status."
+
+    form = TreeStatusUpdateTreesForm(
+        status="approval required",
+    )
+    assert (
+        form.validate_reason(form.reason) is None
+    ), "No validation required for `approval required` status."
+
+    # `closed` status requires a reason.
+    form = TreeStatusUpdateTreesForm(
+        status="closed",
+    )
+    with pytest.raises(ValidationError):
+        form.validate_reason(form.reason)
+
+    form = TreeStatusUpdateTreesForm(
+        status="closed",
+        reason="some reason",
+    )
+    assert (
+        form.validate_reason(form.reason) is None
+    ), "`closed` status with a reason is valid."
 
 
 def test_update_form_validate_reason_category():

--- a/tests/test_treestatus.py
+++ b/tests/test_treestatus.py
@@ -5,9 +5,7 @@
 import pytest
 
 from wtforms.validators import ValidationError
-
 from landoui.forms import (
-    RecentChangesAction,
     TreeStatusRecentChangesForm,
     TreeStatusUpdateTreesForm,
 )

--- a/tests/test_treestatus.py
+++ b/tests/test_treestatus.py
@@ -171,8 +171,26 @@ def test_update_form_validate_reason_category(app):
     ), "`closed` status with valid reason category is valid."
 
 
-def test_update_form_to_submitted_json():
-    pass
+def test_update_form_to_submitted_json(app):
+    form = TreeStatusUpdateTreesForm(
+        status="open",
+        reason="reason",
+        message_of_the_day="",
+        remember=True,
+        reason_category="backlog",
+    )
+
+    form.trees.append_entry("autoland")
+    form.trees.append_entry("mozilla-central")
+
+    assert form.to_submitted_json() == {
+        "status": "open",
+        "reason": "reason",
+        "message_of_the_day": "",
+        "remember": True,
+        "tags": ["backlog"],
+        "trees": ["autoland", "mozilla-central"],
+    }, "JSON format should match expected."
 
 
 def test_recent_changes_action():


### PR DESCRIPTION
Implement a Treestatus UI in Lando. All endpoints in the new
interface are namespaced under `/treestatus`. The main components
are as follows.

The main Treestatus page displays all trees and their current statuses.
When authenticated, each tree can be selected for updating via a checkbox,
or a "select all trees" button is available for CI-wide tree closures.
The tree selections are forwarded to the update form when "Update trees"
is selected.

The "update trees" view implements a form for updating the status of
trees. Trees can be set to open, closed and "approval required". When
the status is being set to a non-open state, a reason and reason
category must be specified. The form presents a "remember this change"
option which can be used to easily revert the change at a later time.
For example if all trees are closed, the trees can be mass re-opened
easily.

The individual log view of a tree presents the most recent status
updates for each individual tree. When authenticated, users can edit
the tree status reason or category in case of a typo or error during
submission by clicking the "edit" button, which toggles the display to a
form for updating.

The recent changes view is a header that appears for authenticated users
on all pages. It presents all status updates that have been "remembered"
during update. Users can edit the reason and reason category using an
"edit" button that toggles the display to a form. The "restore" button
can be used to revert the status change. The "discard" button can be
used to throw away the status change if it is no longer necessary to
remember the change.

The Treestatus UI uses message flashing and the existing Lando-UI
notifications component to present errors and action verification to the
user.
