### PR TITLE
fix(circleci): Using CIRCLE_TAG in develop and stage image tags (bug 1870070)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,11 +85,11 @@ jobs:
                 docker tag "mozilla/landoui" "${DOCKERHUB_REPO}:${CIRCLE_TAG}"
                 docker push "${DOCKERHUB_REPO}:${CIRCLE_TAG}"
               elif [[ ${CIRCLE_BRANCH} == develop ]]; then
-                docker tag "mozilla/landoui" "${DOCKERHUB_REPO}:develop-latest"
-                docker push "${DOCKERHUB_REPO}:develop-latest"
+                docker tag "mozilla/landoui" "${DOCKERHUB_REPO}:develop-${CIRCLE_TAG}"
+                docker push "${DOCKERHUB_REPO}:develop-${CIRCLE_TAG}"
               elif [[ ${CIRCLE_BRANCH} == staging ]]; then
-                docker tag "mozilla/landoui" "${DOCKERHUB_REPO}:staging-latest"
-                docker push "${DOCKERHUB_REPO}:staging-latest"
+                docker tag "mozilla/landoui" "${DOCKERHUB_REPO}:staging-${CIRCLE_TAG}"
+                docker push "${DOCKERHUB_REPO}:staging-${CIRCLE_TAG}"
               fi
             fi
 


### PR DESCRIPTION
Using CIRCLE_TAG in development and staging image tags to build immutable tags for deployment.