### PR TITLE
landing-preview: add a shim to display `blockers` dryrun info if available (Bug 1888188)

### DIFF
--- a/landoui/templates/stack/partials/landing-preview.html
+++ b/landoui/templates/stack/partials/landing-preview.html
@@ -14,6 +14,11 @@
   <div class="StackPage-landingPreview-section StackPage-landingPreview-blocker">
     {{ dryrun['blocker']|escape_html|linkify_faq|safe }}
   </div>
+{% elif dryrun['blockers'] %}
+  <h3 class="StackPage-landingPreview-sectionLabel">Landing is Blocked</h3>
+  <div class="StackPage-landingPreview-section StackPage-landingPreview-blocker">
+    {{ dryrun['blockers'][0]|escape_html|linkify_faq|safe }}
+  </div>
 {% elif series %}
   <h3 class="StackPage-landingPreview-sectionLabel">
     Landing To: &nbsp;

--- a/landoui/templates/stack/partials/landing-preview.html
+++ b/landoui/templates/stack/partials/landing-preview.html
@@ -9,15 +9,11 @@
   <div class="StackPage-landingPreview-section StackPage-landingPreview-blocker">
     Reason for blockage is unknown
   </div>
-{% elif dryrun['blocker'] %}
+{% elif dryrun['blocker'] or dryrun['blockers'] %}
+  {% set blocker = dryrun['blockers'][0] if 'blockers' in dryrun else dryrun['blocker'] %}
   <h3 class="StackPage-landingPreview-sectionLabel">Landing is Blocked</h3>
   <div class="StackPage-landingPreview-section StackPage-landingPreview-blocker">
-    {{ dryrun['blocker']|escape_html|linkify_faq|safe }}
-  </div>
-{% elif dryrun['blockers'] %}
-  <h3 class="StackPage-landingPreview-sectionLabel">Landing is Blocked</h3>
-  <div class="StackPage-landingPreview-section StackPage-landingPreview-blocker">
-    {{ dryrun['blockers'][0]|escape_html|linkify_faq|safe }}
+    {{ blocker|escape_html|linkify_faq|safe }}
   </div>
 {% elif series %}
   <h3 class="StackPage-landingPreview-sectionLabel">

--- a/landoui/templates/stack/partials/revision-status.html
+++ b/landoui/templates/stack/partials/revision-status.html
@@ -16,6 +16,18 @@
     {{revision['blocked_reason']|escape_html|linkify_faq|safe}}
   </div>
 </div>
+{% elif revision['blocked_reasons'] %}
+<div class="StackPage-blockerReason">
+  <div class="Badge Badge--negative">
+    Blocked
+    <span class="icon is-small">
+      <i class="fa fa-info-circle"></i>
+    </span>
+  </div>
+  <div class="StackPage-blockerReason-tooltip">
+    {{revision['blocked_reasons'][0]|escape_html|linkify_faq|safe}}
+  </div>
+</div>
 {% endif %}
 {% set status = revision['status'] %}
 <div class="{{ status['value']|revision_status_to_badge_class }}">

--- a/landoui/templates/stack/partials/revision-status.html
+++ b/landoui/templates/stack/partials/revision-status.html
@@ -4,7 +4,8 @@
     file, You can obtain one at https://mozilla.org/MPL/2.0/.
 #}
 
-{% if revision['blocked_reason'] %}
+{% if revision['blocked_reasons'] or revision['blocked_reason'] %}
+{% set blocked_reason = revision['blocked_reasons'][0] if 'blocked_reasons' in revision else revision['blocked_reason']%}
 <div class="StackPage-blockerReason">
   <div class="Badge Badge--negative">
     Blocked
@@ -14,18 +15,6 @@
   </div>
   <div class="StackPage-blockerReason-tooltip">
     {{revision['blocked_reason']|escape_html|linkify_faq|safe}}
-  </div>
-</div>
-{% elif revision['blocked_reasons'] %}
-<div class="StackPage-blockerReason">
-  <div class="Badge Badge--negative">
-    Blocked
-    <span class="icon is-small">
-      <i class="fa fa-info-circle"></i>
-    </span>
-  </div>
-  <div class="StackPage-blockerReason-tooltip">
-    {{revision['blocked_reasons'][0]|escape_html|linkify_faq|safe}}
   </div>
 </div>
 {% endif %}


### PR DESCRIPTION
As part of the checks refactor we will eventually support displaying
multiple blockers in the front end. Add a shim so Lando-UI can handle
output from before and after the refactor PR in LandoAPI is landed
and deployed.
