### PR TITLE
revision-status: use `blocked_reason` variable instead of pre-refactor key (Bug 1888188)

### DIFF
--- a/landoui/templates/stack/partials/revision-status.html
+++ b/landoui/templates/stack/partials/revision-status.html
@@ -14,7 +14,7 @@
     </span>
   </div>
   <div class="StackPage-blockerReason-tooltip">
-    {{revision['blocked_reason']|escape_html|linkify_faq|safe}}
+    {{blocked_reason|escape_html|linkify_faq|safe}}
   </div>
 </div>
 {% endif %}


### PR DESCRIPTION
In the original revision I added a `blocked_reason` variable to avoid repeated
code, however I forgot to update the template to actually use the variable.
