### PR TITLE
treestatus: handle 404 from tree logs reponse properly (Bug 1896642)

### DIFF
--- a/landoui/treestatus.py
+++ b/landoui/treestatus.py
@@ -219,7 +219,7 @@ def treestatus_tree(tree: str):
 
         error = f"Error received from LandoAPI: {exc.detail}"
         logger.error(error)
-        flash(error, error)
+        flash(error, "error")
         return redirect(request.referrer, code=exc.status_code)
 
     logs = logs_response.get("result")

--- a/landoui/treestatus.py
+++ b/landoui/treestatus.py
@@ -220,7 +220,7 @@ def treestatus_tree(tree: str):
         error = f"Error received from LandoAPI: {exc.detail}"
         logger.error(error)
         flash(error, error)
-        return redirect(request.referrer, code=exc.status)
+        return redirect(request.referrer, code=exc.status_code)
 
     logs = logs_response.get("result")
     if not logs:

--- a/landoui/treestatus.py
+++ b/landoui/treestatus.py
@@ -229,7 +229,7 @@ def treestatus_tree(tree: str):
             f"Could not retrieve status logs for {tree} from Lando, try again later.",
             "error",
         )
-        return redirect(request.referrer, code=404)
+        return redirect(request.referrer)
 
     current_log = logs[0]
 

--- a/landoui/treestatus.py
+++ b/landoui/treestatus.py
@@ -213,23 +213,23 @@ def treestatus_tree(tree: str):
 
     try:
         logs_response = api.request("GET", f"trees/{tree}/logs")
-
-        # We got a response, if this is empty is it an error.
-        logs = logs_response.get("result")
-        detail = "empty response from Lando"
     except LandoAPIError as exc:
         if not exc.detail:
-            raise exc
+            raise
 
-        # We got some exception back from LandoAPI..
-        detail = exc.detail
-        logs = []
-
-    if not logs:
-        error = (f"Could not retrieve status logs for {tree}: {detail}.",)
+        error = f"Error received from LandoAPI: {exc.detail}"
         logger.error(error)
-        flash(error, "error")
-        return redirect(request.referrer)
+        flash(error, error)
+        return redirect(request.referrer, code=exc.status)
+
+    logs = logs_response.get("result")
+    if not logs:
+        logger.error(f"Could not retrieve logs for tree {tree}.")
+        flash(
+            f"Could not retrieve status logs for {tree} from Lando, try again later.",
+            "error",
+        )
+        return redirect(request.referrer, code=404)
 
     current_log = logs[0]
 

--- a/landoui/treestatus.py
+++ b/landoui/treestatus.py
@@ -214,7 +214,7 @@ def treestatus_tree(tree: str):
     try:
         logs_response = api.request("GET", f"trees/{tree}/logs")
     except LandoAPIError as exc:
-        if not exc.detail:
+        if not exc.detail or not exc.status_code:
             raise
 
         error = f"Error received from LandoAPI: {exc.detail}"


### PR DESCRIPTION
When calling out to the tree logs endpoint, we do not properly
handle non-2XX reponse codes within LandoUI, as those throw a
`LandoAPIError` which must be handled. Add a `try/except` block
around the error to properly handle tree names that return 404
from LandoAPI and other errors.
