### PR TITLE
treestatus: check for user authentication before `require_auth0` API calls (Bug 1896642)

### DIFF
--- a/landoui/treestatus.py
+++ b/landoui/treestatus.py
@@ -14,6 +14,7 @@ from flask import (
 )
 
 from landoui.helpers import (
+    is_user_authenticated,
     set_last_local_referrer,
 )
 from landoui.landoapi import (
@@ -126,6 +127,10 @@ def update_treestatus(api: TreestatusAPI, update_trees_form: TreeStatusUpdateTre
     Treestatus page on success. Display an error message and return to the form if
     the status updating rules were broken or the API returned an error.
     """
+    if not is_user_authenticated():
+        flash("Authentication is required to update tree statuses.")
+        return redirect(request.referrer)
+
     logger.info(f"Requesting tree status update.")
 
     try:
@@ -170,6 +175,10 @@ def new_tree():
 
 def new_tree_handler(api: TreestatusAPI, form: TreeStatusNewTreeForm):
     """Handler for the new tree form."""
+    if not is_user_authenticated():
+        flash("Authentication is required to create new trees.")
+        return redirect(request.referrer)
+
     # Retrieve data from the form.
     tree = form.tree.data
     tree_category = form.category.data
@@ -256,6 +265,10 @@ def update_change(id: int):
     stack. This includes pressing the "restore" or "discard" buttons, as well as updates
     to the reason and reason category after pressing "edit" and "update".
     """
+    if not is_user_authenticated():
+        flash("Authentication is required to update stack entries.")
+        return redirect(request.referrer)
+
     api = TreestatusAPI.from_environment()
     recent_changes_form = TreeStatusRecentChangesForm()
 
@@ -294,6 +307,10 @@ def update_log(id: int):
     This function handles form submissions for updates to individual log entries
     in the per-tree log view.
     """
+    if not is_user_authenticated():
+        flash("Authentication is required to update log entries.")
+        return redirect(request.referrer)
+
     api = TreestatusAPI.from_environment()
 
     log_update_form = TreeStatusLogUpdateForm()

--- a/landoui/treestatus.py
+++ b/landoui/treestatus.py
@@ -129,7 +129,7 @@ def update_treestatus(api: TreestatusAPI, update_trees_form: TreeStatusUpdateTre
     """
     if not is_user_authenticated():
         flash("Authentication is required to update tree statuses.")
-        return redirect(request.referrer)
+        return redirect(request.referrer, code=401)
 
     logger.info(f"Requesting tree status update.")
 
@@ -177,7 +177,7 @@ def new_tree_handler(api: TreestatusAPI, form: TreeStatusNewTreeForm):
     """Handler for the new tree form."""
     if not is_user_authenticated():
         flash("Authentication is required to create new trees.")
-        return redirect(request.referrer)
+        return redirect(request.referrer, code=401)
 
     # Retrieve data from the form.
     tree = form.tree.data
@@ -267,7 +267,7 @@ def update_change(id: int):
     """
     if not is_user_authenticated():
         flash("Authentication is required to update stack entries.")
-        return redirect(request.referrer)
+        return redirect(request.referrer, code=401)
 
     api = TreestatusAPI.from_environment()
     recent_changes_form = TreeStatusRecentChangesForm()
@@ -309,7 +309,7 @@ def update_log(id: int):
     """
     if not is_user_authenticated():
         flash("Authentication is required to update log entries.")
-        return redirect(request.referrer)
+        return redirect(request.referrer, code=401)
 
     api = TreestatusAPI.from_environment()
 


### PR DESCRIPTION
In other parts of Lando, before making an API call that uses
the `require_auth0` kwarg, we do an explicit check that the
user is authenticated and handle unauthenticated requests
appropriately. This was overlooked in implementing the Treestatus
UI and is resulting in errors in Sentry since we instead
only discover the missing credentials when making the request,
resulting in an unhandled exception. Add an explicit check
to each handler which makes an `auth0_required` API call.
