### PR TITLE
templates: hide Treestatus editing capabilities from unprivileged users (Bug 1901484)

### DIFF
--- a/landoui/template_helpers.py
+++ b/landoui/template_helpers.py
@@ -11,7 +11,7 @@ import urllib.parse
 
 from typing import Optional
 
-from flask import Blueprint, current_app, escape
+from flask import Blueprint, current_app, escape, session
 from landoui.forms import (
     ReasonCategory,
     TreeCategory,
@@ -30,6 +30,30 @@ template_helpers = Blueprint("template_helpers", __name__)
 @template_helpers.app_template_global()
 def is_user_authenticated() -> bool:
     return helpers.is_user_authenticated()
+
+
+@template_helpers.app_template_global()
+def is_treestatus_user() -> bool:
+    if not is_user_authenticated():
+        return False
+
+    try:
+        userinfo = session["userinfo"]
+    except KeyError:
+        return False
+
+    try:
+        groups = userinfo["https://sso.mozilla.com/claim/groups"]
+    except KeyError:
+        return False
+
+    return any(
+        group in groups
+        for group in {
+            "mozilliansorg_treestatus_admins",
+            "mozilliansorg_treestatus_users",
+        }
+    )
 
 
 @template_helpers.app_template_global()

--- a/landoui/template_helpers.py
+++ b/landoui/template_helpers.py
@@ -38,14 +38,10 @@ def is_treestatus_user() -> bool:
         return False
 
     try:
-        userinfo = session["userinfo"]
+        groups = session["userinfo"]["https://sso.mozilla.com/claim/groups"]
     except KeyError:
         return False
 
-    try:
-        groups = userinfo["https://sso.mozilla.com/claim/groups"]
-    except KeyError:
-        return False
 
     return any(
         group in groups

--- a/landoui/template_helpers.py
+++ b/landoui/template_helpers.py
@@ -32,6 +32,12 @@ def is_user_authenticated() -> bool:
     return helpers.is_user_authenticated()
 
 
+TREESTATUS_USER_GROUPS = {
+    "mozilliansorg_treestatus_admins",
+    "mozilliansorg_treestatus_users",
+}
+
+
 @template_helpers.app_template_global()
 def is_treestatus_user() -> bool:
     if not is_user_authenticated():
@@ -42,14 +48,7 @@ def is_treestatus_user() -> bool:
     except KeyError:
         return False
 
-
-    return any(
-        group in groups
-        for group in {
-            "mozilliansorg_treestatus_admins",
-            "mozilliansorg_treestatus_users",
-        }
-    )
+    return not TREESTATUS_USER_GROUPS.isdisjoint(groups)
 
 
 @template_helpers.app_template_global()

--- a/landoui/templates/treestatus/trees.html
+++ b/landoui/templates/treestatus/trees.html
@@ -12,7 +12,9 @@
     <h1>Treestatus</h1>
     <p>Current status of Mozilla's version-control repositories.</p>
 
+    {% if is_treestatus_user() %}
     {% include "treestatus/recent_changes.html" %}
+    {% endif %}
 
     <h1>Trees</h1>
     {#
@@ -22,7 +24,7 @@
     <form method="post">
         {{ treestatus_update_trees_form.csrf_token }}
 
-        {% if is_user_authenticated() %}
+        {% if is_treestatus_user() %}
         <div class="block">
             <a href="{{ url_for("treestatus.new_tree") }}">
                 <button class="button" title="New Tree" type="button">New Tree</button>
@@ -47,7 +49,7 @@
 
             <div class="select-trees-box box">
                 <div class="columns">
-                    {% if is_user_authenticated() %}
+                    {% if is_treestatus_user() %}
                         <div class="column is-1">
                             <input class="tree-select-checkbox" type="checkbox" name="{{ tree_option.id }}" value="{{ tree_option.data }}">
                         </div>


### PR DESCRIPTION
Add a new `is_treestatus_user` template helper which checks for
membership in the Treestatus Mozillians groups. Switch to using
this new function to determine if Treestatus editing elements of
the UI should be shown.
