### PR TITLE
Fix misaligned warning checkboxes.

### DIFF
--- a/landoui/assets_src/css/pages/StackPage.scss
+++ b/landoui/assets_src/css/pages/StackPage.scss
@@ -144,7 +144,7 @@ ul.StackPage-blockers {
     border-color: #A53030;
     color:#A53030;
     margin-bottom: 4px;
-    padding: 3px 9px 3px 30px;
+    padding: 3px 9px;
     position: relative;
   }
 }
@@ -276,12 +276,6 @@ ul.StackPage-blockers {
     margin-bottom: 4px;
     padding: 3px 9px 3px 30px;
     position: relative;
-
-    input {
-      position: absolute;
-      top: 10px;
-      left: 8px;
-    }
   }
 
   &-blocker {


### PR DESCRIPTION
This lets the browser position the checkbox to the baseline rather than manually positioning it.