### PR TITLE
treestatus: format timestamps as human-readable dates with relative time

### DIFF
--- a/landoui/template_helpers.py
+++ b/landoui/template_helpers.py
@@ -12,6 +12,7 @@ import urllib.parse
 from typing import Optional
 
 from flask import Blueprint, current_app, escape, session
+import humanize
 from landoui.forms import (
     ReasonCategory,
     TreeCategory,
@@ -64,6 +65,15 @@ def new_settings_form() -> UserSettingsForm:
 @template_helpers.app_template_filter()
 def escape_html(text: str) -> str:
     return escape(text)
+
+
+@template_helpers.app_template_filter()
+def format_datetime(iso_string: str) -> str:
+    """Format an ISO 8601 timestamp into a human-readable string with relative time."""
+    dt = datetime.datetime.fromisoformat(iso_string)
+    formatted = dt.strftime("%B %d, %Y, %I:%M %p %Z")
+    relative = humanize.naturaltime(datetime.datetime.now(datetime.timezone.utc) - dt)
+    return f"{formatted} ({relative})"
 
 
 @template_helpers.app_template_global()

--- a/landoui/templates/stack/partials/timeline.html
+++ b/landoui/templates/stack/partials/timeline.html
@@ -13,7 +13,7 @@
         </div>
 
         <div class="StackPage-timeline-itemDetail">
-            <p>Landing requested on <time data-timestamp="{{ transplant['created_at'] }}"></time>, by {{ transplant['requester_email'] }}.</p>
+            <p>Landing requested on {{ transplant['created_at'] | format_datetime }}, by {{ transplant['requester_email'] }}.</p>
             <p><strong>Revisions:</strong>
             {% for i in transplant['landing_path'] %}{{
             "" if loop.first else " ← "

--- a/landoui/templates/treestatus/log.html
+++ b/landoui/templates/treestatus/log.html
@@ -28,7 +28,7 @@
                             <span class="{{ log.status | treestatus_to_status_badge_class }}">{{ log.status }}</span>
                         </div>
                         <div class="column is-expanded">
-                            <div class="block"><b>{{ log.when }}</b></div>
+                            <div class="block"><b>{{ log.when | format_datetime }}</b></div>
                             <div class="block"><h2 class="subtitle">{{ log.who }}</h2></div>
                             <div class="block">
                                 {% if log.reason %}

--- a/landoui/templates/treestatus/recent_changes.html
+++ b/landoui/templates/treestatus/recent_changes.html
@@ -15,7 +15,7 @@
 
             <div class="columns">
                 <div class="column">
-                    <p>At {{ status_change_data.when }}, <b>{{ status_change_data.who }}</b> changed trees:</p>
+                    <p>At {{ status_change_data.when | format_datetime }}, <b>{{ status_change_data.who }}</b> changed trees:</p>
                     <div class="block content">
                         <ul>
                             {% for tree in status_change_data.trees %}

--- a/requirements.in
+++ b/requirements.in
@@ -12,6 +12,7 @@ cryptography==3.3.2
 flake8==3.7.9
 flask-assets==0.12
 flask-pyoidc==3.7.0
+humanize==4.13.0
 oic==1.2.1
 # Required by flask-pyoidc, can be removed when flask-pyoidc is updated.
 mako>=1.2.2


### PR DESCRIPTION
Use python-humanize to display timestamps like
"March 25, 2026, 01:08 PM UTC (2 hours ago)" instead of raw ISO 8601.
