### PR TITLE
js: include relative time-delta in formatted timestamps (Bug 2026363)

### DIFF
--- a/landoui/assets_src/js/components/Treestatus.js
+++ b/landoui/assets_src/js/components/Treestatus.js
@@ -8,6 +8,11 @@
 
 $.fn.treestatus = function() {
     return this.each(function() {
+        let $treestatus = $(this);
+
+        // Format timestamps.
+        $treestatus.find('time[data-timestamp]').formatTime();
+
         // Register an on-click handler for each log update edit button.
         $('.log-update-edit').on("click", function () {
             // Toggle the elements from hidden/visible.

--- a/landoui/assets_src/js/utils/formatTime.js
+++ b/landoui/assets_src/js/utils/formatTime.js
@@ -6,6 +6,26 @@
 
 'use strict';
 
+const RELATIVE_UNITS = [
+  { unit: 'year',   seconds: 31536000 },
+  { unit: 'month',  seconds: 2592000 },
+  { unit: 'week',   seconds: 604800 },
+  { unit: 'day',    seconds: 86400 },
+  { unit: 'hour',   seconds: 3600 },
+  { unit: 'minute', seconds: 60 },
+  { unit: 'second', seconds: 1 },
+];
+
+const relativeFormatter = new Intl.RelativeTimeFormat('en', { numeric: 'auto' });
+
+function humanizeTimeDelta(date, now = new Date()) {
+  const deltaSeconds = Math.round((date - now) / 1000);
+  const match = RELATIVE_UNITS.find((entry) => Math.abs(deltaSeconds) >= entry.seconds);
+  return match
+    ? relativeFormatter.format(Math.round(deltaSeconds / match.seconds), match.unit)
+    : relativeFormatter.format(deltaSeconds, 'second');
+}
+
 $.fn.formatTime = function() {
   return this.each(function() {
     let time = $(this).data('timestamp');
@@ -19,6 +39,8 @@ $.fn.formatTime = function() {
       timeZoneName: 'short',
       hour: 'numeric',
       minute: 'numeric'
-    }));
+    // We can't use string interpolation as the minifier eats the
+    // empty space between the timestamp and the humanized time delta.
+    }) + ' (' + humanizeTimeDelta(date) + ')');
   });
 };

--- a/landoui/templates/treestatus/log.html
+++ b/landoui/templates/treestatus/log.html
@@ -28,7 +28,7 @@
                             <span class="{{ log.status | treestatus_to_status_badge_class }}">{{ log.status }}</span>
                         </div>
                         <div class="column is-expanded">
-                            <div class="block"><b>{{ log.when }}</b></div>
+                            <div class="block"><b><time data-timestamp="{{ log.when }}"></time></b></div>
                             <div class="block"><h2 class="subtitle">{{ log.who }}</h2></div>
                             <div class="block">
                                 {% if log.reason %}

--- a/landoui/templates/treestatus/recent_changes.html
+++ b/landoui/templates/treestatus/recent_changes.html
@@ -15,7 +15,7 @@
 
             <div class="columns">
                 <div class="column">
-                    <p>At {{ status_change_data.when }}, <b>{{ status_change_data.who }}</b> changed trees:</p>
+                    <p>At <time data-timestamp="{{ status_change_data.when }}"></time>, <b>{{ status_change_data.who }}</b> changed trees:</p>
                     <div class="block content">
                         <ul>
                             {% for tree in status_change_data.trees %}


### PR DESCRIPTION
Update formatTime to use Intl.RelativeTimeFormat to include
a human-readable time delta. Timestamps will now appear like
"Wed, August 13, 2025 at 11:02 PM EDT (7 months ago)", so it
is immediately obvious how much time has passed since the
timestamp was recorded.

Update some timestamps to use the `<time>` tag to take
advantage of the new formatting.
